### PR TITLE
Refactor get_O_loc

### DIFF
--- a/jVMC/operator/base.py
+++ b/jVMC/operator/base.py
@@ -151,7 +151,7 @@ class Operator(metaclass=abc.ABCMeta):
 
         return jax.vmap(lambda x, y, z: jnp.sum(x * jnp.exp(z - y)), in_axes=(0, 0, 0))(matEl, logPsiS, logPsiSP.reshape(matEl.shape))
 
-    def get_O_loc(self, samples, psi, logPsiS, *args):
+    def get_O_loc(self, samples, psi, logPsiS=None, *args):
         """Compute :math:`O_{loc}(s)`.
 
         If the instance parameter ElocBatchSize is larger than 0 :math:`O_{loc}(s)` is computed in a batch-wise manner
@@ -166,6 +166,9 @@ class Operator(metaclass=abc.ABCMeta):
         Returns:
             :math:`O_{loc}(s)` for each configuration :math:`s`.
         """
+
+        if logPsiS is None:
+            logPsiS = psi(samples)
 
         if self.ElocBatchSize > 0:
             return self.get_O_loc_batched(samples, psi, logPsiS, self.ElocBatchSize, *args)

--- a/jVMC/operator/base.py
+++ b/jVMC/operator/base.py
@@ -53,12 +53,13 @@ class Operator(metaclass=abc.ABCMeta):
 
     """
 
-    def __init__(self):
+    def __init__(self, ElocBatchSize=-1):
         """Initialize ``Operator``.
         """
 
         self.compiled = False
         self.compiled_argnum = -1
+        self.ElocBatchSize = ElocBatchSize
 
         # pmap'd member functions
         self._get_s_primes_pmapd = None

--- a/jVMC/operator/branch_free.py
+++ b/jVMC/operator/branch_free.py
@@ -147,7 +147,7 @@ class BranchFreeOperator(Operator):
         * ``lDim``: Dimension of local Hilbert space.
     """
 
-    def __init__(self, lDim=2):
+    def __init__(self, lDim=2, **kwargs):
         """Initialize ``Operator``.
 
         Arguments:
@@ -156,7 +156,7 @@ class BranchFreeOperator(Operator):
         self.ops = []
         self.lDim = lDim
 
-        super().__init__()
+        super().__init__(**kwargs)
 
     def add(self, opDescr):
         """Add another operator to the operator

--- a/jVMC/operator/povm.py
+++ b/jVMC/operator/povm.py
@@ -338,13 +338,13 @@ class POVMOperator(Operator):
         * ``lDim``: Dimension of local Hilbert space.
     """
 
-    def __init__(self, povm, ldim=4):
+    def __init__(self, povm, ldim=4, **kwargs):
         """Initialize ``Operator``.
         """
         self.povm = povm
         self.ldim = ldim
         self.ops = []
-        super().__init__()
+        super().__init__(**kwargs)
 
     def add(self, opDescr):
         """Add another operator to the operator.

--- a/jVMC/util/tdvp.py
+++ b/jVMC/util/tdvp.py
@@ -266,11 +266,7 @@ class TDVP:
 
         # Evaluate local energy
         start_timing(outp, "compute Eloc")
-        sampleOffdConfigs, matEls = hamiltonian.get_s_primes(sampleConfigs, t)
-        start_timing(outp, "evaluate off-diagonal")
-        sampleLogPsiOffd = psi(sampleOffdConfigs)
-        stop_timing(outp, "evaluate off-diagonal", waitFor=sampleLogPsiOffd)
-        Eloc = hamiltonian.get_O_loc(sampleLogPsi, sampleLogPsiOffd)
+        Eloc = hamiltonian.get_O_loc(sampleConfigs, psi, sampleLogPsi, t)
         stop_timing(outp, "compute Eloc", waitFor=Eloc)
 
         # Evaluate gradients

--- a/jVMC/util/util.py
+++ b/jVMC/util/util.py
@@ -157,10 +157,8 @@ def measure(observables, psi, sampler, numSamples=None):
             if isinstance(op, collections.abc.Iterable):
                 args = tuple(op[1:])
                 op = op[0]
-            
-            sampleOffdConfigs, matEls = op.get_s_primes(sampleConfigs, *args)
-            sampleLogPsiOffd = psi(sampleOffdConfigs)
-            Oloc = op.get_O_loc(sampleLogPsi, sampleLogPsiOffd)
+
+            Oloc = op.get_O_loc(sampleConfigs, psi, sampleLogPsi, *args)
 
             if p is not None:
                 tmpMeans.append(mpi.global_mean(Oloc, p))

--- a/tests/operator_t.py
+++ b/tests/operator_t.py
@@ -39,7 +39,7 @@ class TestOperator(unittest.TestCase):
         logPsi=jnp.ones(s.shape[:-1])
         logPsiSP=jnp.ones(sp.shape[:-1])
 
-        tmp = h.get_O_loc(logPsi,logPsiSP)
+        tmp = h.get_O_loc_unbatched(logPsi, logPsiSP)
 
         self.assertTrue( jnp.sum(jnp.abs( tmp - 2. * jnp.sum(-(s[...,:3]-1), axis=-1) )) < 1e-7 )
 
@@ -64,7 +64,7 @@ class TestOperator(unittest.TestCase):
             logPsi=jnp.ones(s.shape[:-1])
             logPsiSP=jnp.ones(sp.shape[:-1])
 
-            tmp = h.get_O_loc(logPsi,logPsiSP)
+            tmp = h.get_O_loc_unbatched(logPsi, logPsiSP)
 
             self.assertTrue( jnp.sum(jnp.abs( tmp - f(t) * jnp.sum(-(s[...,:3]-1), axis=-1) )) < 1e-7 )
 
@@ -87,7 +87,7 @@ class TestOperator(unittest.TestCase):
 
         sp, matEl = h.get_s_primes(s)
         logPsiSp = psi(sp)
-        Oloc1 = h.get_O_loc(logPsi, logPsiSp)
+        Oloc1 = h.get_O_loc_unbatched(logPsi, logPsiSp)
         
         batchSize = 13
         Oloc2 = h.get_O_loc_batched(s, psi, logPsi, batchSize)


### PR DESCRIPTION
Refactored get_O_loc method to include batched calculation if required. The batch size for this can be specified at the definition of the operator.