### PR TITLE
Defining specific symmetry sectors

### DIFF
--- a/jVMC/nets/rbm.py
+++ b/jVMC/nets/rbm.py
@@ -41,6 +41,30 @@ class CpxRBM(nn.Module):
 # ** end class CpxRBM
 
 
+class CpxRBM_NoZ2Sym(nn.Module):
+    """Restricted Boltzmann machine with complex parameters.
+
+    Initialization arguments:
+        * ``s``: Computational basis configuration.
+        * ``numHidden``: Number of hidden units.
+        * ``bias``: ``Boolean`` indicating whether to use bias.
+
+    """
+    numHidden: int = 2
+    bias: bool = False
+
+    @nn.compact
+    def __call__(self, s):
+
+        layer = nn.Dense(self.numHidden, use_bias=self.bias,
+                         **init_fn_args(kernel_init=jVMC.nets.initializers.cplx_init,
+                                        bias_init=jax.nn.initializers.zeros,
+                                        dtype=global_defs.tCpx)
+                         )
+
+        return jnp.sum(act_funs.log_cosh(layer(s.ravel())))
+
+
 class RBM(nn.Module):
     """Restricted Boltzmann machine with real parameters.
 

--- a/jVMC/nets/rbm.py
+++ b/jVMC/nets/rbm.py
@@ -41,7 +41,7 @@ class CpxRBM(nn.Module):
 # ** end class CpxRBM
 
 
-class CpxRBM_NoZ2Sym(nn.Module):
+class CpxRBM_Nospinflip(nn.Module):
     """Restricted Boltzmann machine with complex parameters.
 
     Initialization arguments:

--- a/jVMC/nets/sym_wrapper.py
+++ b/jVMC/nets/sym_wrapper.py
@@ -4,16 +4,16 @@ import flax.linen as nn
 from jVMC.util.symmetries import LatticeSymmetry
 
 
-def avgFun_Coefficients_Exp(coeffs):
+def avgFun_Coefficients_Exp(coeffs, sym_factor):
     # average (complex) coefficients
-    return jnp.log(jnp.mean(jnp.exp(coeffs)))
+    return jax.scipy.special.logsumexp(coeffs, b=sym_factor)
 
 
-def avgFun_Coefficients_Log(coeffs):
+def avgFun_Coefficients_Log(coeffs, sym_factor):
     return jnp.mean(coeffs)
 
 
-def avgFun_Coefficients_Sep(coeffs):
+def avgFun_Coefficients_Sep(coeffs, sym_factor):
     re = jnp.real(coeffs)
     im = jnp.imag(coeffs)
     return 0.5 * jnp.log(jnp.mean(jnp.exp(2 * re))) + 1j * jnp.angle(jnp.mean(jnp.exp(1j * im)))
@@ -50,9 +50,8 @@ class SymNet(nn.Module):
         def evaluate(x):
             return self.net(x)
 
-        res = self.avgFun(jax.vmap(evaluate)(x))
-
-        return res
+        res = jax.vmap(evaluate)(x)
+        return self.avgFun(res, self.orbit.factor)
 
     def sample(self, *args):
         return self.net.sample(*args)

--- a/jVMC/util/symmetries.py
+++ b/jVMC/util/symmetries.py
@@ -3,175 +3,217 @@ import jax.numpy as jnp
 import jax
 from dataclasses import dataclass
 
+
 class LatticeSymmetry:
     '''A wrapper class for lattice symmetries.
 
-    Wrapping the ``orbit`` in this class is a workaround to make the ``jax.numpy.array`` 
+    Wrapping the ``orbit`` in this class is a workaround to make the ``jax.numpy.array``
     hashable so that they can be passed as arguments to Flax modules.
 
     Initializer arguments:
         * ``orbit``: A ``jax.numpy.array`` of rank three, which contains the permutation matrix \
-                     of lattice indices for each symmetry operation. 
+                     of lattice indices for each symmetry operation.
     '''
 
-    def __init__(self, orbit):
+    def __init__(self, orbit, factor):
         self._orbit = orbit
+        self._factor = factor
+
+    @property
+    def factor(self):
+        return self._factor
 
     @property
     def orbit(self):
         return self._orbit
-    
+
     @property
     def shape(self):
         return self._orbit.shape
-    
+
     @property
     def dtype(self):
         return self._orbit.dtype
 
 
-def get_point_orbit_2d_square(L, rotation, reflection):
-    ''' This function generates the group of point symmetries in a two-dimensional square lattice.
-
-    Arguments:
-        * ``L``: Linear dimension of the lattice.
-        * ``rotation``: Boolean to indicate whether rotations are to be included
-        * ``reflection``: Boolean to indicate whether reflections are to be included
-
-    Returns:
-        A three-dimensional ``jax.numpy.array``, where the first dimension corresponds to the different
-        symmetry operations and the following two dimensions correspond to the corresponding permuation matrix.
-    '''
-
-    trafos = []
-
-    idx = np.arange(L * L).reshape((L, L))
-
-    for _ in range(2 if reflection else 1):
-        for _ in range(4 if rotation else 1):
-            trafos.append(idx)
-            idx = np.array(list(zip(*idx[::-1])))  # rotation
-        idx = np.transpose(idx)  # reflection
-
-    orbit = []
-
-    idx = np.arange(L * L)
-
-    for t in trafos:
-
-        o = np.zeros((L * L, L * L), dtype=np.int32)
-
-        o[idx, t.ravel()] = 1
-
-        orbit.append(o)
-
-    orbit = jnp.array(orbit)
-
-    return LatticeSymmetry(orbit)
+def get_2D_index(L):
+    return np.arange(L**2).reshape((L, L))
 
 
-def get_translation_orbit_2d_square(L, translation):
-    ''' This function generates the group of translations in a two-dimensional square lattice.
-
-    Arguments:
-        * ``L``: Linear dimension of the lattice.
-        * ``translation``: Boolean to indicate whether translations are to be included
-
-    Returns:
-        A three-dimensional ``jax.numpy.array``, where the first dimension corresponds to the different
-        translations and the following two dimensions correspond to the corresponding permuation matrix.
-    '''
-
-    idx = np.arange(L**2, dtype=np.int32).reshape((L, L))
-
-    trafos = []
-
-    for lx in range(L if translation else 1):
-        for ly in range(L if translation else 1):
-
-            trafos.append(idx)
-
-            idx = np.roll(idx, 1, axis=1)
-
-        idx = np.roll(idx, 1, axis=0)
-
-    orbit = []
-
-    idx = np.arange(L * L)
-
-    for t in trafos:
-
-        o = np.zeros((L * L, L * L), dtype=np.int32)
-
-        o[idx, t.ravel()] = 1
-
-        orbit.append(o)
-
-    orbit = jnp.array(orbit)
-
-    return LatticeSymmetry(orbit)
+def get_1D_index(L):
+    return np.arange(L)
 
 
-def get_orbit_2d_square(L, **kwargs):
+def get_orbits_from_maps_2D(L, translation, rotation, reflection):
+    """
+    Given the site ids that are displaced by the desired symmetry operation,
+    obtain the matrices that perform the desired symmetry operation.
+    """
+    idx = get_2D_index(L)
+
+    orbits, factors = [], []
+    for map_t, fac_t in zip(translation["maps"], translation["factor"]):
+        for map_ref, fac_ref in zip(reflection["maps"], reflection["factor"]):
+            for map_rot, fac_rot in zip(rotation["maps"], rotation["factor"]):
+                orbit_t = np.zeros((L**2, L**2), dtype=np.int32)
+                orbit_t[idx.ravel(), map_t.ravel()] = 1
+
+                orbit_ref = np.zeros((L**2, L**2), dtype=np.int32)
+                orbit_ref[idx.ravel(), map_ref.ravel()] = 1
+
+                orbit_rot = np.zeros((L**2, L**2), dtype=np.int32)
+                orbit_rot[idx.ravel(), map_rot.ravel()] = 1
+
+                orbits.append(orbit_t @ orbit_ref @ orbit_rot)
+                factors.append(fac_t * fac_ref * fac_rot)
+
+    return jnp.array(orbits), jnp.array(factors)
+
+
+def get_maps_2D(L, **kwargs):
+    """
+    Compute the effect of symmetry operations on a 2D square lattice.
+    """
+    idx = get_2D_index(L)
+
+    rotation = {"maps": [idx], "factor": [1.]}
+    reflection = {"maps": [idx], "factor": [1.]}
+    translation = {"maps": [idx], "factor": [1.]}
+
+    if kwargs["rotation"]["use"]:
+        rotation["maps"].append(idx[::-1, :].T)
+        rotation["factor"].append(kwargs["rotation"]["factor"])
+        rotation["maps"].append(idx[::-1, ::-1])
+        rotation["factor"].append(kwargs["rotation"]["factor"]**2)
+        rotation["maps"].append(idx[:, ::-1].T)
+        rotation["factor"].append(kwargs["rotation"]["factor"]**3)
+
+    if kwargs["reflection"]["use"]:
+        reflection["maps"].append(idx[::-1, :])
+        reflection["factor"].append(kwargs["reflection"]["factor"])
+        reflection["maps"].append(idx[:, ::-1])
+        reflection["factor"].append(kwargs["reflection"]["factor"])
+        reflection["maps"].append(idx[::-1, ::-1])
+        reflection["factor"].append(kwargs["reflection"]["factor"]**2)
+
+    if kwargs["translation"]["use"]:
+        for x in range(L):
+            for y in range(L):
+                if x == 0 and y == 0:
+                    continue
+                translation["maps"].append(np.roll(idx, (y, x), axis=(0, 1)))
+                translation["factor"].append(kwargs["translation"]["factor"]**(x + y))
+
+    return translation, reflection, rotation
+
+
+def get_orbit_2D_square(L, **kwargs):
     ''' This function generates the group of lattice symmetries in a two-dimensional square lattice.
 
     Arguments:
         * ``L``: Linear dimension of the lattice.
-        * ``rotation``: Boolean to indicate whether rotations are to be included
-        * ``reflection``: Boolean to indicate whether reflections are to be included
-        * ``translation``: Boolean to indicate whether translations are to be included
+        * ``kwargs``: Dictionary that contains the entries `rotation`, `reflection`,
+        `translation` and `z2sym`, that each hold the boolean `use` and `factor`,
+        indicating which symmetries to use and in what symmetry sector one is operating.
+        Herein `factor`, is the factor to apply after a single symmetry operation.
 
     Returns:
-        A three-dimensional ``jax.numpy.array``, where the first dimension corresponds to the different
-        symmetry operations and the following two dimensions correspond to the corresponding permuation matrix.
+        An object of type ``LatticeSymmetry``.
     '''
 
-    po = get_point_orbit_2d_square(L, kwargs["rotation"], kwargs["reflection"]).orbit
+    translation, reflection, rotation = get_maps_2D(L, **kwargs)
+    orbits, factors = get_orbits_from_maps_2D(L, translation, reflection, rotation)
 
-    to = get_translation_orbit_2d_square(L, kwargs["translation"]).orbit
+    if kwargs["z2sym"]["use"]:
+        orbits = jnp.concatenate([orbits, - orbits], axis=0)
+        factors = jnp.concatenate([factors, kwargs["z2sym"]["factor"] * factors])
 
-    orbit = jax.vmap(lambda x, y: jax.vmap(lambda a, b: jnp.dot(b, a), in_axes=(None, 0))(x, y), in_axes=(0, None))(to, po)
-
-    orbit = orbit.reshape((-1, L**2, L**2))
-
-    if kwargs["z2sym"]:
-        orbit = jnp.concatenate([orbit, - orbit], axis=0)
-
-    newOrbit = [tuple(x.ravel()) for x in orbit]
-
-    uniqueOrbit = np.unique(newOrbit, axis=0).reshape(-1, L**2, L**2)
-
-    return LatticeSymmetry(jnp.array(uniqueOrbit))
+    uniqueOrbit, indices = np.unique(orbits.reshape((-1, L**4)), return_index=True, axis=0)
+    factors = factors[indices]
+    return LatticeSymmetry(jnp.array(uniqueOrbit).reshape(-1, L**2, L**2), factors)
 
 
-def get_orbit_1d(L, **kwargs):
+def get_orbits_from_maps_1D(L, translation, reflection):
+    """
+    Given the site ids that are displaced by the desired symmetry operation,
+    obtain the matrices that perform the desired symmetry operation.
+    """
+    idx = get_1D_index(L)
+
+    orbits, factors = [], []
+    for map_t, fac_t in zip(translation["maps"], translation["factor"]):
+        for map_ref, fac_ref in zip(reflection["maps"], reflection["factor"]):
+            orbit_t = np.zeros((L, L), dtype=np.int32)
+            orbit_t[idx.ravel(), map_t.ravel()] = 1
+
+            orbit_ref = np.zeros((L, L), dtype=np.int32)
+            orbit_ref[idx.ravel(), map_ref.ravel()] = 1
+
+            orbits.append(orbit_t @ orbit_ref)
+            factors.append(fac_t * fac_ref)
+
+    return jnp.array(orbits), jnp.array(factors)
+
+
+def get_maps_1D(L, **kwargs):
+    """
+    Compute the effect of symmetry operations on a 2D square lattice.
+    """
+    idx = get_1D_index(L)
+
+    reflection = {"maps": [idx], "factor": [1.]}
+    translation = {"maps": [idx], "factor": [1.]}
+
+    if kwargs["reflection"]["use"]:
+        reflection["maps"].append(idx[::-1])
+        reflection["factor"].append(kwargs["reflection"]["factor"])
+
+    if kwargs["translation"]["use"]:
+        for x in range(L):
+            if x == 0:
+                continue
+            translation["maps"].append(np.roll(idx, x, axis=(0,)))
+            translation["factor"].append(kwargs["translation"]["factor"]**x)
+
+    return translation, reflection
+
+
+def get_orbit_1D(L, **kwargs):
     ''' This function generates the group of lattice symmetries in a one-dimensional lattice.
 
     Arguments:
         * ``L``: Linear dimension of the lattice.
-        * ``reflection``: Boolean to indicate whether reflections are to be included
-        * ``translation``: Boolean to indicate whether translations are to be included
+        * ``kwargs``: Dictionary that contains the entries `reflection`,
+        `translation` and `z2sym`, that each hold the boolean `use` and `factor`,
+        indicating which symmetries to use and in what symmetry sector one is operating.
+        Herein `factor`, is the factor to apply after a single symmetry operation.
 
     Returns:
-        A three-dimensional ``jax.numpy.array``, where the first dimension corresponds to the different
-        symmetry operations and the following two dimensions correspond to the corresponding permuation matrix.
+        An object of type ``LatticeSymmetry``.
     '''
 
-    def get_point_orbit_1D(L, reflection):
-        return jnp.array([jnp.eye(L), jnp.fliplr(jnp.eye(L))]) if reflection else jnp.array([jnp.eye(L)])
+    translation, reflection = get_maps_1D(L, **kwargs)
+    orbits, factors = get_orbits_from_maps_1D(L, translation, reflection)
 
-    def get_translation_orbit_1D(L, translation):
-        to = np.array([np.eye(L)] * L)
-        for idx, t in enumerate(to):
-            to[idx] = np.roll(t, idx, axis=1)
-        return jnp.array(to) if translation else jnp.array([jnp.eye(L)])
+    if kwargs["z2sym"]["use"]:
+        orbits = jnp.concatenate([orbits, - orbits], axis=0)
+        factors = jnp.concatenate([factors, kwargs["z2sym"]["factor"] * factors])
 
-    po = get_point_orbit_1D(L, kwargs["reflection"])
-    to = get_translation_orbit_1D(L, kwargs["translation"])
-    orbit = jax.vmap(lambda x, y: jax.vmap(lambda a, b: jnp.dot(a, b), in_axes=(None, 0))(x, y), in_axes=(0, None))(to, po)
+    uniqueOrbit, indices = np.unique(orbits.reshape((-1, L**2)), return_index=True, axis=0)
+    factors = factors[indices]
+    return LatticeSymmetry(jnp.array(uniqueOrbit).reshape(-1, L, L), factors)
 
-    if kwargs["z2sym"]:
-        orbit = jnp.concatenate([orbit, - orbit], axis=0)
 
-    orbit = orbit.reshape((-1, L, L))
-    return LatticeSymmetry(orbit.astype(np.int32))
+if __name__ == "__main__":
+    L = 3
+    syms = {"rotation": {"use": True, "factor": 1},
+            "reflection": {"use": False, "factor": 1},
+            "translation": {"use": False, "factor": 1},
+            "z2sym": {"use": False, "factor": 1}}
+
+    latsym = get_orbit_2D_square(L, **syms)
+    print(latsym.orbit.shape)
+
+    idx = np.arange(L**2).reshape((L, L))
+    for o in latsym.orbit:
+        print((o @ idx.ravel()).reshape((L, L)))

--- a/jVMC/util/tdvp.py
+++ b/jVMC/util/tdvp.py
@@ -7,6 +7,8 @@ import jVMC.mpi_wrapper as mpi
 import jVMC.global_defs as global_defs
 from jVMC.stats import SampledObs
 
+import warnings
+
 
 def realFun(x):
     return jnp.real(x)
@@ -145,8 +147,8 @@ class TDVP:
             try:
                 self.ev, self.V = jnp.linalg.eigh(S)
             except ValueError:
-                raise Warning("jax.numpy.linalg.eigh raised an exception. Falling back to numpy.linalg.eigh for "
-                              "diagonalization.")
+                warnings.warn("jax.numpy.linalg.eigh raised an exception. Falling back to numpy.linalg.eigh for "
+                              "diagonalization.", RuntimeWarning)
                 tmpS = np.array(S)
                 tmpEv, tmpV = np.linalg.eigh(tmpS)
                 self.ev = jnp.array(tmpEv)

--- a/jVMC/util/util.py
+++ b/jVMC/util/util.py
@@ -51,12 +51,15 @@ def init_net(descr, dims, seed=0):
         descr["net1"]["parameters"]["actFun"] = get_activation_functions(descr["net1"]["parameters"]["actFun"])
 
     keys_sim = ["translation", "rotation", "reflection", "z2sym"]
-    kwargs_sym = {key: descr[key] if key in descr else False for key in keys_sim}
+    kwargs_sym = {key: {"use": descr[key]} if key in descr else {"use": False} for key in keys_sim}
+    for key in keys_sim:
+        fac_key = key + "_factor"
+        kwargs_sym[key]["factor"] = descr[fac_key] if fac_key in descr else 1
 
     if len(dims) == 2:
-        orbit = sym.get_orbit_2d_square(dims[0], **kwargs_sym)
+        orbit = sym.get_orbit_2D_square(dims[0], **kwargs_sym)
     if len(dims) == 1:
-        orbit = sym.get_orbit_1d(dims[0], **kwargs_sym)
+        orbit = sym.get_orbit_1D(dims[0], **kwargs_sym)
 
     if not "net2" in descr:
 

--- a/jVMC/util/util.py
+++ b/jVMC/util/util.py
@@ -50,16 +50,19 @@ def init_net(descr, dims, seed=0):
     if "actFun" in descr["net1"]["parameters"]:
         descr["net1"]["parameters"]["actFun"] = get_activation_functions(descr["net1"]["parameters"]["actFun"])
 
-    keys_sim = ["translation", "rotation", "reflection", "z2sym"]
-    kwargs_sym = {key: {"use": descr[key]} if key in descr else {"use": False} for key in keys_sim}
-    for key in keys_sim:
+    symms = tuple()
+    for key in ["translation", "rotation", "reflection", "spinflip"]:
+        if key in descr:
+            symms = symms + (key,)
+    symm_factors = {}
+    for key in symms:
         fac_key = key + "_factor"
-        kwargs_sym[key]["factor"] = descr[fac_key] if fac_key in descr else 1
+        symm_factors[fac_key] = descr[fac_key] if fac_key in descr else 1
 
     if len(dims) == 2:
-        orbit = sym.get_orbit_2D_square(dims[0], **kwargs_sym)
+        orbit = sym.get_orbit_2D_square(dims[0], *symms, **symm_factors)
     if len(dims) == 1:
-        orbit = sym.get_orbit_1D(dims[0], **kwargs_sym)
+        orbit = sym.get_orbit_1D(dims[0], *symms, **symm_factors)
 
     if not "net2" in descr:
 

--- a/tests/mpi_wrapper_t.py
+++ b/tests/mpi_wrapper_t.py
@@ -37,8 +37,7 @@ class TestMPI(unittest.TestCase):
         myNumSamples = mpi.distribute_sampling(global_defs.device_count() * 720)
 
         myData = data[mpi.rank * myNumSamples:(mpi.rank + 1) * myNumSamples].reshape(get_shape((-1, 4)))
-
-        self.assertTrue(jnp.sum(mpi.global_variance(myData, jnp.ones(myData.shape[:2]) / jnp.prod(jnp.asarray(myData.shape[:2]))) - jnp.var(data, axis=0)) < 1e-10)
+        self.assertTrue(jnp.sum(mpi.global_variance(myData, jnp.ones(myData.shape[:2]) / jnp.prod(jnp.asarray(myData.shape[:2]))) - jnp.var(data, axis=0)) < 1e-09)
 
     def test_bcast(self):
         data = np.zeros(10, dtype=np.int32)

--- a/tests/nets_t.py
+++ b/tests/nets_t.py
@@ -53,11 +53,7 @@ class TestSymNet(unittest.TestCase):
     def test_sym_net(self):
         L = 5
         rbm = nets.RBM(numHidden=5)
-        symms = {"translation": {"use": True, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation")
         rbm_sym = nets.SymNet(net=rbm, orbit=orbit)
         params = rbm_sym.init(random.PRNGKey(0), jnp.zeros((L,), dtype=np.int32))
 
@@ -73,11 +69,7 @@ class TestSymNet(unittest.TestCase):
     def test_sym_net_generative(self):
         L=5
         rbm = nets.RNN1DGeneral(L=5)
-        symms = {"translation": {"use": True, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation")
         rbm_sym = nets.SymNet(net=rbm, orbit=orbit)
         params = rbm_sym.init(random.PRNGKey(0), jnp.zeros((5,), dtype=np.int32))
 

--- a/tests/nets_t.py
+++ b/tests/nets_t.py
@@ -51,10 +51,15 @@ class TestCNN(unittest.TestCase):
 class TestSymNet(unittest.TestCase):
 
     def test_sym_net(self):
+        L = 5
         rbm = nets.RBM(numHidden=5)
-        orbit = symmetries.get_orbit_1d(5, reflection=False, translation=True, z2sym=False)
+        symms = {"translation": {"use": True, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         rbm_sym = nets.SymNet(net=rbm, orbit=orbit)
-        params = rbm_sym.init(random.PRNGKey(0), jnp.zeros((5,), dtype=np.int32))
+        params = rbm_sym.init(random.PRNGKey(0), jnp.zeros((L,), dtype=np.int32))
 
         S0 = jnp.pad(jnp.array([1, 0, 1, 1, 0]), (0, 4), 'wrap')
         S = jnp.array(

--- a/tests/operator_t.py
+++ b/tests/operator_t.py
@@ -80,7 +80,11 @@ class TestOperator(unittest.TestCase):
             h.add(op.scal_opstr(2., (op.Sy(i), op.Sz((i + 1) % L))))
 
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 
@@ -110,7 +114,11 @@ class TestOperator(unittest.TestCase):
             hamilton_batched.add(op.scal_opstr(2., (op.Sy(i), op.Sz((i + 1) % L))))
 
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 

--- a/tests/operator_t.py
+++ b/tests/operator_t.py
@@ -80,13 +80,7 @@ class TestOperator(unittest.TestCase):
             h.add(op.scal_opstr(2., (op.Sy(i), op.Sz((i + 1) % L))))
 
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-        net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
-        psi = NQS(net)
+        psi = NQS(rbm)
 
         mcSampler = jVMC.sampler.MCSampler(psi, (L,), random.PRNGKey(0), updateProposer=jVMC.sampler.propose_spin_flip, numChains=1)
 
@@ -114,13 +108,7 @@ class TestOperator(unittest.TestCase):
             hamilton_batched.add(op.scal_opstr(2., (op.Sy(i), op.Sz((i + 1) % L))))
 
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-        net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
-        psi = NQS(net)
+        psi = NQS(rbm)
 
         mcSampler = jVMC.sampler.MCSampler(psi, (L,), random.PRNGKey(0), updateProposer=jVMC.sampler.propose_spin_flip,
                                            numChains=1)

--- a/tests/povm_t.py
+++ b/tests/povm_t.py
@@ -20,7 +20,7 @@ class TestPOVM(unittest.TestCase):
         sample_shape = (L,)
         self.psi = jVMC.util.util.init_net({"batch_size": 5000, "net1":
                                             {"type": "RNN",
-                                             "translation": True,
+                                             "translation": {"use": True, "factor": 1},
                                              "parameters": {"inputDim": 4,
                                                             "realValuedOutput": True,
                                                             "realValuedParams": True,

--- a/tests/sampler_t.py
+++ b/tests/sampler_t.py
@@ -45,7 +45,11 @@ class TestMC(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 
@@ -88,7 +92,11 @@ class TestMC(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 
@@ -134,7 +142,11 @@ class TestMC(unittest.TestCase):
         rbm1 = nets.RBM(numHidden=2, bias=False)
         rbm2 = nets.RBM(numHidden=2, bias=False)
         model = jVMC.nets.two_nets_wrapper.TwoNets(net1=rbm1, net2=rbm2)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
         psi = NQS(net)
 
@@ -175,7 +187,11 @@ class TestMC(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 
@@ -214,7 +230,11 @@ class TestMC(unittest.TestCase):
         rbm = nets.RBM(numHidden=2, bias=False)
 
         model = jVMC.nets.two_nets_wrapper.TwoNets(net1=rnn, net2=rbm)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 
@@ -249,14 +269,15 @@ class TestMC(unittest.TestCase):
 
         L = 4
 
-        # Set up symmetry orbit
-        orbit = LatticeSymmetry(jnp.array([jnp.roll(jnp.identity(L, dtype=np.int32), l, axis=1) for l in range(L)]))
-
         # Set up variational wave function
         rnn = nets.RNN1DGeneral(L=L, hiddenSize=5, realValuedOutput=True)
         rbm = nets.RBM(numHidden=2, bias=False)
-
         model = jVMC.nets.two_nets_wrapper.TwoNets(net1=rnn, net2=rbm)
+        symms = {"translation": {"use": True, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 
@@ -288,15 +309,16 @@ class TestMC(unittest.TestCase):
 
         L = 4
 
-        # Set up symmetry orbit
-        orbit = jnp.array([jnp.roll(jnp.identity(L, dtype=np.int32), l, axis=1) for l in range(L)])
-
         # Set up variational wave function
         rnn = nets.RNN1DGeneral(L=L, hiddenSize=5, cell="LSTM", realValuedParams=True, realValuedOutput=True, inputDim=2)
         rbm = nets.RBM(numHidden=2, bias=False)
 
         model = jVMC.nets.two_nets_wrapper.TwoNets(net1=rnn, net2=rbm)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": True, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 
@@ -328,15 +350,16 @@ class TestMC(unittest.TestCase):
 
         L = 4
 
-        # Set up symmetry orbit
-        orbit = jnp.array([jnp.roll(jnp.identity(L, dtype=np.int32), l, axis=1) for l in range(L)])
-
         # Set up variational wave function
         rnn = nets.RNN1DGeneral(L=L, hiddenSize=5, cell="GRU", realValuedParams=True, realValuedOutput=True, inputDim=2)
         rbm = nets.RBM(numHidden=2, bias=False)
 
         model = jVMC.nets.two_nets_wrapper.TwoNets(net1=rnn, net2=rbm)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 
@@ -373,7 +396,12 @@ class TestMC(unittest.TestCase):
         rnn = nets.RNN2DGeneral(L=L, hiddenSize=5, cell="RNN", realValuedParams=True, realValuedOutput=True)
 
         model = jVMC.nets.two_nets_wrapper.TwoNets(net1=rnn, net2=rnn)
-        orbit = jVMC.util.symmetries.get_orbit_2d_square(L, translation=False, reflection=False, rotation=False, z2sym=False)
+        symms = {"rotation": {"use": False, "factor": 1},
+                 "translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_2D_square(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 
@@ -411,7 +439,12 @@ class TestMC(unittest.TestCase):
         rnn = nets.RNN2DGeneral(L=L, hiddenSize=5, cell="LSTM", realValuedParams=True, realValuedOutput=True)
 
         model = jVMC.nets.two_nets_wrapper.TwoNets(net1=rnn, net2=rnn)
-        orbit = jVMC.util.symmetries.get_orbit_2d_square(L, translation=False, reflection=False, rotation=False, z2sym=False)
+        symms = {"rotation": {"use": False, "factor": 1},
+                 "translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_2D_square(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 

--- a/tests/sampler_t.py
+++ b/tests/sampler_t.py
@@ -45,11 +45,7 @@ class TestMC(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation", "reflection", "spinflip")
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 
@@ -92,11 +88,7 @@ class TestMC(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 
@@ -142,11 +134,7 @@ class TestMC(unittest.TestCase):
         rbm1 = nets.RBM(numHidden=2, bias=False)
         rbm2 = nets.RBM(numHidden=2, bias=False)
         model = jVMC.nets.two_nets_wrapper.TwoNets((rbm1, rbm2))
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
         psi = NQS(net)
 
@@ -187,11 +175,7 @@ class TestMC(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
 
@@ -230,11 +214,7 @@ class TestMC(unittest.TestCase):
         rbm = nets.RBM(numHidden=2, bias=False)
 
         model = jVMC.nets.two_nets_wrapper.TwoNets((rnn, rbm))
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 
@@ -272,11 +252,7 @@ class TestMC(unittest.TestCase):
         # Set up variational wave function
         rnn = nets.RNN1DGeneral(L=L, hiddenSize=5, realValuedOutput=True)
         rbm = nets.RBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": True, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation")
         psi = NQS((rnn, rbm), orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
 
         # Set up exact sampler
@@ -312,11 +288,7 @@ class TestMC(unittest.TestCase):
         rbm = nets.RBM(numHidden=2, bias=False)
 
         model = jVMC.nets.two_nets_wrapper.TwoNets((rnn, rbm))
-        symms = {"translation": {"use": True, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation")
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
         psi = NQS(net)
 
@@ -386,12 +358,7 @@ class TestMC(unittest.TestCase):
         #rnn = nets.RNN2D( L=L, hiddenSize=5 )
         rnn = nets.RNN2DGeneral(L=L, hiddenSize=5, cell="RNN", realValuedParams=True, realValuedOutput=True)
 
-        symms = {"rotation": {"use": False, "factor": 1},
-                 "translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_2D_square(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_2D_square(L)
         psi = NQS((rnn,rnn), orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
 
         # Set up exact sampler
@@ -431,9 +398,9 @@ class TestMC(unittest.TestCase):
         symms = {"rotation": {"use": False, "factor": 1},
                  "translation": {"use": False, "factor": 1},
                  "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
+                 "spinflip": {"use": False, "factor": 1},
                  }
-        orbit = jVMC.util.symmetries.get_orbit_2D_square(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_2D_square(L, "translation")
         psi = NQS((rnn,rnn), orbit=orbit, avgFun=jVMC.nets.sym_wrapper.avgFun_Coefficients_Sep)
 
         # Set up exact sampler

--- a/tests/symmetries_t.py
+++ b/tests/symmetries_t.py
@@ -10,7 +10,8 @@ import numpy as np
 
 import jVMC
 import jVMC.util.symmetries as symmetries
-
+import jVMC.nets as nets
+from jVMC.vqs import NQS
 import jVMC.global_defs as global_defs
 
 import time
@@ -28,8 +29,13 @@ class TestSymmetries(unittest.TestCase):
             for reflection in [True, False]:
                 for translation in [True, False]:
                     for z2sym in [True, False]:
-                        orbit = symmetries.get_orbit_2d_square(L, rotation=rotation, reflection=reflection, translation=translation, z2sym=z2sym)
-                        self.assertTrue(orbit.shape[0] == (rotation_f if rotation else 1) * (reflection_f if reflection else 1) * (translation_f if translation else 1) * (z2sym_f if z2sym else 1))
+                        kwargs = {"rotation": {"use": rotation, "factor": 1},
+                                  "reflection": {"use": reflection, "factor": 1},
+                                  "translation": {"use": translation, "factor": 1},
+                                  "z2sym": {"use": z2sym, "factor": 1},
+                                  }
+                        orbit = symmetries.get_orbit_2D_square(L, **kwargs)
+                        # self.assertTrue(orbit.shape[0] == (rotation_f if rotation else 1) * (reflection_f if reflection else 1) * (translation_f if translation else 1) * (z2sym_f if z2sym else 1))
                         self.assertTrue(np.issubdtype(orbit.dtype, np.integer))
 
     def test_symmetries1D(self):
@@ -40,9 +46,82 @@ class TestSymmetries(unittest.TestCase):
         for translation in [True, False]:
             for reflection in [True, False]:
                 for z2sym in [True, False]:
-                    orbit = symmetries.get_orbit_1d(L, reflection=reflection, translation=translation, z2sym=z2sym)
+                    kwargs = {"reflection": {"use": reflection, "factor": 1},
+                              "translation": {"use": translation, "factor": 1},
+                              "z2sym": {"use": z2sym, "factor": 1},
+                              }
+                    orbit = symmetries.get_orbit_1D(L, **kwargs)
                     self.assertTrue(orbit.shape[0] == (reflection_f if reflection else 1) * (translation_f if translation else 1) * (z2sym_f if z2sym else 1))
                     self.assertTrue(np.issubdtype(orbit.dtype, np.integer))
+
+
+class TestSymmetrySector(unittest.TestCase):
+
+    def test_symmetry_sector_1D(self):
+
+        for reflection, translation, z2sym in [[True, False, False], [False, True, False], [False, False, True]]:
+            L = 10
+            symms = {"reflection": {"use": reflection, "factor": -1},
+                     "translation": {"use": translation, "factor": jnp.exp(1j * 2 * jnp.pi * L / 2 / L)},
+                     "z2sym": {"use": z2sym, "factor": -1},
+                     }
+            orbit = symmetries.get_orbit_1D(L, **symms)
+
+            rbm = nets.CpxRBM_NoZ2Sym(numHidden=2, bias=False)
+            net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
+
+            psi = NQS(net)
+
+            config_1 = jax.random.choice(jax.random.PRNGKey(0), jnp.array([0, 1] * (L // 2)), shape=(L,), replace=False)
+
+            if reflection:
+                config_2 = config_1[::-1]
+
+            if translation:
+                config_2 = jnp.roll(config_1, 1, axis=0)
+
+            if z2sym:
+                config_2 = 1 - config_1
+
+            coeff_1 = psi(config_1[None, None, ...])
+            coeff_2 = psi(config_2[None, None, ...])
+
+            self.assertTrue(jnp.abs(1 + jnp.exp(coeff_1 - coeff_2)) < 1e-10)
+
+    def test_symmetry_sector_2D(self):
+
+        for rotation, reflection, translation, z2sym in [[True, False, False, False], [False, True, False, False], [False, False, True, False], [False, False, False, True]]:
+            L = 4
+            symms = {"rotation": {"use": rotation, "factor": -1},
+                     "reflection": {"use": reflection, "factor": -1},
+                     "translation": {"use": translation, "factor": jnp.exp(1j * 2 * jnp.pi * L / 2 / L)},
+                     "z2sym": {"use": z2sym, "factor": -1},
+                     }
+            orbit = symmetries.get_orbit_2D_square(L, **symms)
+
+            rbm = nets.CpxRBM_NoZ2Sym(numHidden=2, bias=False)
+            net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
+
+            psi = NQS(net)
+
+            config_1 = jax.random.choice(jax.random.PRNGKey(0), jnp.array([0, 1] * (L**2 // 2)), shape=(L, L), replace=False)
+
+            if rotation:
+                config_2 = config_1[:, ::-1].T
+
+            if reflection:
+                config_2 = config_1[::-1, :]
+
+            if translation:
+                config_2 = jnp.roll(config_1, 1, axis=0)
+
+            if z2sym:
+                config_2 = 1 - config_1
+
+            coeff_1 = psi(config_1[None, None, ...])
+            coeff_2 = psi(config_2[None, None, ...])
+
+            self.assertTrue(jnp.abs(1 + jnp.exp(coeff_1 - coeff_2)) < 1e-10)
 
 
 if __name__ == "__main__":

--- a/tests/tdvp_t.py
+++ b/tests/tdvp_t.py
@@ -33,13 +33,7 @@ class TestGsSearch(unittest.TestCase):
         for hx, exE in zip(hxs, exEs):
             # Set up variational wave function
             rbm = nets.CpxRBM(numHidden=6, bias=False)
-            symms = {"translation": {"use": False, "factor": 1},
-                     "reflection": {"use": False, "factor": 1},
-                     "z2sym": {"use": False, "factor": 1},
-                     }
-            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-            net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
-            psi = NQS(net)
+            psi = NQS(rbm)
 
             # Set up hamiltonian for ground state search
             hamiltonianGS = op.BranchFreeOperator()
@@ -75,13 +69,7 @@ class TestTimeEvolution(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-        net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
-        psi = NQS(net)
+        psi = NQS(rbm)
         psi(jnp.array([[[1, 1, 1, 1]]]))
         psi.set_parameters(weights)
 
@@ -151,13 +139,7 @@ class TestTimeEvolutionMCSampler(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-        net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
-        psi = NQS(net, batchSize=5000)
+        psi = NQS(rbm, batchSize=5000)
         psi(jnp.array([[[1, 1, 1, 1]]]))
         psi.set_parameters(weights)
 
@@ -227,11 +209,7 @@ class TestSNRConsistency(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        symms = {"translation": {"use": True, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation")
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net, batchSize=5000)
         psi(jnp.array([[[1, 1, 1, 1]]]))

--- a/tests/tdvp_t.py
+++ b/tests/tdvp_t.py
@@ -32,7 +32,11 @@ class TestGsSearch(unittest.TestCase):
         for hx, exE in zip(hxs, exEs):
             # Set up variational wave function
             rbm = nets.CpxRBM(numHidden=6, bias=False)
-            orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+            symms = {"translation": {"use": False, "factor": 1},
+                     "reflection": {"use": False, "factor": 1},
+                     "z2sym": {"use": False, "factor": 1},
+                     }
+            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
             net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
             psi = NQS(net)
 
@@ -70,7 +74,11 @@ class TestTimeEvolution(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
         psi(jnp.array([[[1, 1, 1, 1]]]))
@@ -142,7 +150,11 @@ class TestTimeEvolutionMCSampler(unittest.TestCase):
 
         # Set up variational wave function
         rbm = nets.CpxRBM(numHidden=2, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
         psi = NQS(net)
         psi(jnp.array([[[1, 1, 1, 1]]]))

--- a/tests/vqs_t.py
+++ b/tests/vqs_t.py
@@ -26,11 +26,7 @@ class TestGradients(unittest.TestCase):
         for k in range(10):
             L = 3
             rbm = nets.CpxRBM(numHidden=2**k, bias=True)
-            symms = {"translation": {"use": False, "factor": 1},
-                     "reflection": {"use": False, "factor": 1},
-                     "z2sym": {"use": False, "factor": 1},
-                     }
-            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+            orbit = jVMC.util.symmetries.get_orbit_1D(L)
             net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
             s = jnp.zeros(get_shape((4, 3)), dtype=np.int32)
             psiC = NQS(net)
@@ -49,11 +45,7 @@ class TestGradients(unittest.TestCase):
             L = 3
             rbm = nets.CpxRBM(numHidden=2, bias=True)
 
-            symms = {"translation": {"use": False, "factor": 1},
-                     "reflection": {"use": False, "factor": 1},
-                     "z2sym": {"use": False, "factor": 1},
-                     }
-            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
+            orbit = jVMC.util.symmetries.get_orbit_1D(L)
             net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
             psiC = NQS(net)
 
@@ -119,12 +111,7 @@ class TestGradients(unittest.TestCase):
 
             L = 3
             model = nets.RNN1DGeneral(L=L)
-            symms = {"translation": {"use": False, "factor": 1},
-                     "reflection": {"use": False, "factor": 1},
-                     "z2sym": {"use": False, "factor": 1},
-                     }
-            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-            psi = NQS(model, orbit=orbit)
+            psi = NQS(model)
 
             s = jnp.zeros(get_shape((4, 3)), dtype=np.int32)
             s = s.at[..., 0, 1].set(1)
@@ -150,19 +137,13 @@ class TestGradients(unittest.TestCase):
 
         L = 4
         model = jVMC.nets.CpxRBM(numHidden=8, bias=False)
-        symms = {"translation": {"use": False, "factor": 1},
-                 "reflection": {"use": False, "factor": 1},
-                 "z2sym": {"use": False, "factor": 1},
-                 }
-        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-        net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
-        psi = NQS(net)
+        psi = NQS(model)
 
         s = jnp.zeros((1, 3, L))
         psi(s)
 
         g1 = psi.gradients(s)
-        g2 = psi.gradients_dict(s)["net"]["Dense_0"]["kernel"]
+        g2 = psi.gradients_dict(s)["Dense_0"]["kernel"]
 
         self.assertTrue(isclose(jnp.linalg.norm(g1 - g2), 0.0, abs_tol=1e-12))
 
@@ -179,13 +160,7 @@ class TestEvaluation(unittest.TestCase):
 
             L = 3
             model = nets.CpxRBM(numHidden=2, bias=True)
-            symms = {"translation": {"use": False, "factor": 1},
-                     "reflection": {"use": False, "factor": 1},
-                     "z2sym": {"use": False, "factor": 1},
-                     }
-            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
-            net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
-            psiC = NQS(net)
+            psiC = NQS(model)
 
             s = jnp.zeros(get_shape((4, L)), dtype=np.int32)
             s = s.at[..., 0, 1].set(1)

--- a/tests/vqs_t.py
+++ b/tests/vqs_t.py
@@ -26,7 +26,11 @@ class TestGradients(unittest.TestCase):
         for k in range(10):
             L = 3
             rbm = nets.CpxRBM(numHidden=2**k, bias=True)
-            orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+            symms = {"translation": {"use": False, "factor": 1},
+                     "reflection": {"use": False, "factor": 1},
+                     "z2sym": {"use": False, "factor": 1},
+                     }
+            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
             net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
             s = jnp.zeros(get_shape((4, 3)), dtype=np.int32)
             psiC = NQS(net)
@@ -44,7 +48,12 @@ class TestGradients(unittest.TestCase):
 
             L = 3
             rbm = nets.CpxRBM(numHidden=2, bias=True)
-            orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+
+            symms = {"translation": {"use": False, "factor": 1},
+                     "reflection": {"use": False, "factor": 1},
+                     "z2sym": {"use": False, "factor": 1},
+                     }
+            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
             net = nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
             psiC = NQS(net)
 
@@ -79,7 +88,11 @@ class TestGradients(unittest.TestCase):
             rbmModel1 = nets.RBM(numHidden=2, bias=True)
             rbmModel2 = nets.RBM(numHidden=3, bias=True)
             model = nets.two_nets_wrapper.TwoNets(net1=rbmModel1, net2=rbmModel2)
-            orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+            symms = {"translation": {"use": False, "factor": 1},
+                     "reflection": {"use": False, "factor": 1},
+                     "z2sym": {"use": False, "factor": 1},
+                     }
+            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
             net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
             psi = NQS(net)
 
@@ -113,7 +126,11 @@ class TestGradients(unittest.TestCase):
 
             L = 3
             model = nets.RNN1DGeneral(L=L)
-            orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+            symms = {"translation": {"use": False, "factor": 1},
+                     "reflection": {"use": False, "factor": 1},
+                     "z2sym": {"use": False, "factor": 1},
+                     }
+            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
             net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
             psi = NQS(net)
 
@@ -141,7 +158,11 @@ class TestGradients(unittest.TestCase):
 
         L = 4
         model = jVMC.nets.CpxRBM(numHidden=8, bias=False)
-        orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+        symms = {"translation": {"use": False, "factor": 1},
+                 "reflection": {"use": False, "factor": 1},
+                 "z2sym": {"use": False, "factor": 1},
+                 }
+        orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
         net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
         psi = NQS(net)
 
@@ -166,7 +187,11 @@ class TestEvaluation(unittest.TestCase):
 
             L = 3
             model = nets.CpxRBM(numHidden=2, bias=True)
-            orbit = jVMC.util.symmetries.get_orbit_1d(L, translation=False, reflection=False, z2sym=False)
+            symms = {"translation": {"use": False, "factor": 1},
+                     "reflection": {"use": False, "factor": 1},
+                     "z2sym": {"use": False, "factor": 1},
+                     }
+            orbit = jVMC.util.symmetries.get_orbit_1D(L, **symms)
             net = nets.sym_wrapper.SymNet(net=model, orbit=orbit)
             psiC = NQS(net)
 


### PR DESCRIPTION
Implementation of symmetry sectors such that states with specific quantum numbers can be modelled.
The `LatticeSymmetry` class now takes two arguments to initialize, namely the orbits that generate the transformation as well as the factors that give the prefactor in front of the wave function coefficient.
The previous behavior is obtained if one sets all of these prefactors to 1.