### PR TITLE
Add general gradient estimator to SampledObs class.

### DIFF
--- a/jVMC/operator/base.py
+++ b/jVMC/operator/base.py
@@ -306,6 +306,7 @@ class Operator(metaclass=abc.ABCMeta):
             log_psi_s = net_fun(params, config)
             log_psi_sp = jax.vmap(lambda s: net_fun(params,s))(sp)
 
-            return jnp.dot(matEls, jnp.exp(log_psi_sp - log_psi_s))
+            #return jnp.dot(matEls, jnp.exp(log_psi_sp - log_psi_s))
+            return jnp.sum(matEls * jnp.exp(log_psi_sp - log_psi_s))
 
         return op_estimator

--- a/jVMC/operator/base.py
+++ b/jVMC/operator/base.py
@@ -279,3 +279,33 @@ class Operator(metaclass=abc.ABCMeta):
             corresponding matrix elements.
         """
 
+    def get_estimator_function(self, psi, *args):
+        """Get a function that computes :math:`O_{loc}(\\theta, s)`.
+
+        Returns a function that computes :math:`O_{loc}(\\theta, s)=\sum_{s'} O_{s,s'}\\frac{\psi_\\theta(s')}{\psi_\\theta(s)}` 
+        for a given configuration :math:`s` and parameters :math:`\\theta` of a given ansatz :math:`\psi_\\theta(s)`.
+
+        Arguments:
+            * ``psi``: Neural quantum state.
+            * ``*args``: Further positional arguments for the operator.
+
+        Returns:
+            A function :math:`O_{loc}(\\theta, s)`.
+        """
+
+        op_fun = self.compile()
+        if type(op_fun) is tuple:
+            op_fun_args = op_fun[1](*args)
+            op_fun = op_fun[0]
+        net_fun = psi.net.apply
+
+        def op_estimator(params, config):
+
+            sp, matEls = op_fun(config, *op_fun_args)
+
+            log_psi_s = net_fun(params, config)
+            log_psi_sp = jax.vmap(lambda s: net_fun(params,s))(sp)
+
+            return jnp.dot(matEls, jnp.exp(log_psi_sp - log_psi_s))
+
+        return op_estimator

--- a/jVMC/stats.py
+++ b/jVMC/stats.py
@@ -137,9 +137,11 @@ class SampledObs():
     """This class implements the computation of statistics from Monte Carlo or exact samples.
 
     Initializer arguments:
-        * ``observations``: Observations :math:`O_n` in the sample. The array must have a leading device \
-            dimension plus a batch dimension.
+        * ``observations``: Observations :math:`O_n` in the sample. This can be the value of an observable `O(s_n)` or the \
+                plain configuration `s_n`. The array must have a leading device dimension plus a batch dimension.
         * ``weights``: Weights :math:`w_n` associated with observation :math:`O_n`.
+        * ``estimator``: [optional] Function :math:`O(\\theta, s)` that computes an estimator parametrized by :math:`\\theta`
+        * ``params``: [optional] A set of parameters for the estimator function.
     """
 
     def __init__(

--- a/jVMC/stats.py
+++ b/jVMC/stats.py
@@ -181,10 +181,9 @@ class SampledObs():
                 jax.vmap(lambda p, s: estimator(p,s), in_axes=(None, 0)), 
                 in_axes=(None, 0)
                 )
-            
+
             self._estimator_grad = jVMC.global_defs.pmap_for_my_devices(
                                     jax.vmap(lambda p, s: flat_grad(lambda a, b: jnp.real(estimator(a,b)))(p,s) + 1.j*flat_grad(lambda a, b: jnp.imag(estimator(a,b)))(p,s), in_axes=(None, 0)), 
-                                    #jax.vmap(lambda p, s: flat_grad(lambda a, b: jnp.real(estimator(a,b)))(p,s), in_axes=(None, 0)), 
                                     in_axes=(None, 0)
                                     )
             

--- a/jVMC/stats.py
+++ b/jVMC/stats.py
@@ -199,7 +199,7 @@ class SampledObs():
             if len(observations.shape) == 2:
                 observations = observations[...,None]
 
-            self._weights = weights
+            #self._weights = weights
             self._mean = mpi.global_sum( _mean_helper(observations,self._weights)[:, None,...]  )
             self._data = _data_prep(observations, self._weights, self._mean)
 

--- a/jVMC/version.py
+++ b/jVMC/version.py
@@ -1,2 +1,2 @@
 """Current jVMC version at head on Github."""
-__version__ = "1.2.4"
+__version__ = "1.3.0"

--- a/jVMC/vqs.py
+++ b/jVMC/vqs.py
@@ -44,7 +44,6 @@ def eval_batched(batchSize, fun, s):
 
     return res[:s.shape[0]]
 
-
 def flat_gradient(fun, params, arg):
     gr = grad(lambda p, y: jnp.real(fun.apply(p, y)))(params, arg)["params"]
     gr = tree_flatten(tree_map(lambda x: x.ravel(), gr))[0]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 
-DEFAULT_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax>=0.4.1,<=0.4.20", "jaxlib>=0.4.1,<=0.4.20", "flax>=0.6.4,<=0.6.11", "mpi4py", "h5py", "PyYAML", "matplotlib"]
+DEFAULT_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax>=0.4.1,<=0.4.20", "jaxlib>=0.4.1,<=0.4.20", "flax>=0.6.4,<=0.6.11", "mpi4py", "h5py", "PyYAML", "matplotlib", "scipy<1.13"] # Scipy version restricted, because jax is currently incompatible with new function namespace scipy.sparse.tril
 #CUDA_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax[cuda]>=0.2.11,<=0.2.25", "flax>=0.3.6,<=0.3.6", "mpi4py", "h5py"]
 DEV_DEPENDENCIES = DEFAULT_DEPENDENCIES + ["sphinx", "mock", "sphinx_rtd_theme", "pytest", "pytest-mpi"]
 

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import jax
 import jax.numpy as jnp
 
 import jVMC

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -1,10 +1,10 @@
 import unittest
 
-import jax
 import jax.numpy as jnp
 
+import jVMC
 from jVMC.stats import SampledObs
-import jVMC.mpi_wrapper as mpi
+import jVMC.operator as op
 
 
 class TestStats(unittest.TestCase):
@@ -33,3 +33,58 @@ class TestStats(unittest.TestCase):
         O = obs2._data.reshape((-1,2))
         self.assertTrue(jnp.allclose(obs2.tangent_kernel(), jnp.matmul(O, jnp.conj(jnp.transpose(O)))))
 
+
+    def test_estimator(self):
+
+        L = 4
+        
+        for rbm in [jVMC.nets.CpxRBM(numHidden=1, bias=False), jVMC.nets.RBM(numHidden=1, bias=False)]:
+
+            # Set up variational wave function
+            orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation", "reflection")
+            net = jVMC.nets.sym_wrapper.SymNet(net=rbm, orbit=orbit)
+            psi = jVMC.vqs.NQS(net)
+
+            # Set up MCMC sampler
+            # mcSampler = jVMC.sampler.MCSampler(psi, (L,), jax.random.PRNGKey(0), updateProposer=jVMC.sampler.propose_spin_flip, sweepSteps=L+1, numChains=777)
+
+            exactSampler = jVMC.sampler.ExactSampler(psi, (L,))
+
+            p0 = psi.parameters
+
+            # configs, configsLogPsi, p = mcSampler.sample(numSamples=40000)
+
+            configs, configsLogPsi, p = exactSampler.sample()
+
+            h = op.BranchFreeOperator()
+            for i in range(L):
+                h.add(op.scal_opstr(2., (op.Sx(i),)))
+                h.add(op.scal_opstr(2., (op.Sy(i), op.Sz((i + 1) % L))))
+
+            op_estimator = h.get_estimator_function(psi)
+
+            obs1 = SampledObs(configs, p, estimator=op_estimator)
+
+            Oloc = h.get_O_loc(configs, psi)
+            obs2 = SampledObs(Oloc, p)
+            self.assertTrue( jnp.allclose( obs1.mean(p0), obs2.mean() ) )
+
+            psiGrads = SampledObs(psi.gradients(configs), p)
+            Eloc = h.get_O_loc(configs, psi, configsLogPsi)
+            Eloc = SampledObs( Eloc, p )
+
+            Egrad2 = 2*jnp.real( psiGrads.covar(Eloc) )
+
+            self.assertTrue(jnp.allclose( jnp.real(obs1.mean_and_grad(psi, p0)[1]), Egrad2.ravel() ))
+
+
+        # obs1 = SampledObs(weights=pEx, configs=configsEx, estimator=op_estimator)
+        # E0 = obs1.mean(psi.parameters)
+        # p0 = psi.get_parameters()
+        # dp = 1e-6
+        # p0 = p0.at[0].add(dp)
+        # psi.set_parameters(p0)
+        # configsEx, configsLogPsiEx, pEx = exactSampler.sample(parameters=psi.params)
+        # obs1 = SampledObs(weights=pEx, configs=configsEx, estimator=op_estimator)
+        # E1 = obs1.mean(psi.parameters)
+        # print((E1-E0)/dp)


### PR DESCRIPTION
For an expectation value

$\langle O\rangle_\theta=\sum_s\frac{|\psi_\theta(s)|}{\langle\psi_\theta|\psi_\theta\rangle}O_\theta(s)$

the general form of the gradient is

$\partial_\theta\langle O\rangle_\theta=2\langle\text{Re}[\Gamma_\theta] O_\theta\rangle_\theta-2\langle\text{Re}[\Gamma_\theta]\rangle_\theta \langle O_\theta\rangle_\theta+\langle\partial_\theta O_\theta\rangle_\theta$

where $\Gamma_\theta(s)=\partial_\theta\log\psi_\theta(s)$.

This PR implements a `mean_and_grad` member function of the `SampledObs` class that computes the gradient of the expectation value as given above.