### PR TITLE
Fix complex RNN

### DIFF
--- a/jVMC/nets/rnn1d_general.py
+++ b/jVMC/nets/rnn1d_general.py
@@ -112,7 +112,7 @@ class RNN1DGeneral(nn.Module):
             self.initFunction = jax.nn.initializers.variance_scaling(scale=self.initScale, mode="fan_avg", distribution="uniform")
         else:
             self.dtype = global_defs.tCpx
-            self.initFunction = partial(jVMC.nets.initializers.cplx_variance_scaling, scale=self.initScale)
+            self.initFunction = jVMC.nets.initializers.cplx_variance_scaling
 
         if isinstance(self.cell, str):
             self.zero_carry = jnp.zeros((self.depth, 1, self.hiddenSize), dtype=self.dtype)
@@ -129,7 +129,7 @@ class RNN1DGeneral(nn.Module):
             self.cells = self.cell[0]
             self.zero_carry = self.cell[1]
 
-        self.rnnCell = RNNCellStack(self.cells, actFun=self.actFun)
+        self.rnnCell = RNNCellStack(self.cells, actFun=self.actFun, dtype=self.dtype)
         init_args = init_fn_args(dtype=self.dtype, bias_init=jax.nn.initializers.zeros, kernel_init=self.initFunction)
         self.outputDense = nn.Dense(features=(self.inputDim-1) * (2 - self.realValuedOutput),
                                     use_bias=True, **init_args)

--- a/jVMC/nets/rnn2d_general.py
+++ b/jVMC/nets/rnn2d_general.py
@@ -117,7 +117,7 @@ class RNN2DGeneral(nn.Module):
             self.initFunction = jax.nn.initializers.variance_scaling(scale=self.initScale, mode="fan_avg", distribution="uniform")
         else:
             self.dtype = global_defs.tCpx
-            self.initFunction = partial(jVMC.nets.initializers.cplx_variance_scaling, scale=self.initScale)
+            self.initFunction = jVMC.nets.initializers.cplx_variance_scaling
 
         if isinstance(self.cell, str):
             if self.cell in ["LSTM", "GRU"] and not self.realValuedParams:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 
-DEFAULT_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax>=0.4.1,<=0.4.11", "jaxlib>=0.4.1,<=0.4.11", "flax>=0.6.4,<=0.6.11", "mpi4py", "h5py", "PyYAML", "matplotlib"]
+DEFAULT_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax>=0.4.1,<=0.4.20", "jaxlib>=0.4.1,<=0.4.20", "flax>=0.6.4,<=0.6.11", "mpi4py", "h5py", "PyYAML", "matplotlib"]
 #CUDA_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax[cuda]>=0.2.11,<=0.2.25", "flax>=0.3.6,<=0.3.6", "mpi4py", "h5py"]
 DEV_DEPENDENCIES = DEFAULT_DEPENDENCIES + ["sphinx", "mock", "sphinx_rtd_theme", "pytest", "pytest-mpi"]
 

--- a/tests/nets_test.py
+++ b/tests/nets_test.py
@@ -1,5 +1,6 @@
 import unittest
-
+import sys
+sys.path.append(sys.path[0] + "../..")
 import jVMC
 import jVMC.nets as nets
 
@@ -68,19 +69,43 @@ class TestSymNet(unittest.TestCase):
 
     def test_sym_net_generative(self):
         L=5
-        rbm = nets.RNN1DGeneral(L=5)
+        rnn = nets.RNN1DGeneral(L=5)
         orbit = jVMC.util.symmetries.get_orbit_1D(L, "translation")
-        rbm_sym = nets.SymNet(net=rbm, orbit=orbit)
-        params = rbm_sym.init(random.PRNGKey(0), jnp.zeros((5,), dtype=np.int32))
+        rnn_sym = nets.SymNet(net=rnn, orbit=orbit)
+        params = rnn_sym.init(random.PRNGKey(0), jnp.zeros((5,), dtype=np.int32))
 
         S0 = jnp.pad(jnp.array([1, 0, 1, 1, 0]), (0, 4), 'wrap')
         S = jnp.array(
             [S0[i:i + 5]for i in range(5)]
         )
-        psiS = jax.vmap(lambda s: rbm_sym.apply(params, s))(S)
+        psiS = jax.vmap(lambda s: rnn_sym.apply(params, s))(S)
         psiS = psiS - psiS[0]
 
         self.assertTrue(jnp.max(jnp.abs(psiS)) < 1e-12)
+
+
+class TestCpxNet(unittest.TestCase):
+
+    def test_cpx_rnn_1d(self):
+        rnn = nets.RNN1DGeneral(L=5, realValuedParams=False)
+        params = rnn.init(random.PRNGKey(0), jnp.zeros((5,), dtype=np.int32))
+
+        S0 = jnp.array([1, 0, 1, 1, 0])
+        psiS0 = rnn.apply(params, S0)
+        self.assertTrue(jnp.max(jnp.abs(psiS0 - (-1.7393452561818394+0.025880153799492975j))) < 1e-12)
+
+    def test_cpx_rnn_2d(self):
+        rnn = nets.RNN2DGeneral(L=4, realValuedParams=False)
+        params = rnn.init(random.PRNGKey(0), jnp.zeros((4, 4), dtype=np.int32))
+
+        S0 = jnp.array(
+            [[1, 0, 1, 1],
+             [0, 1, 1, 1],
+             [0, 0, 1, 0],
+             [1, 0, 0, 1]]
+        )
+        psiS0 = rnn.apply(params, S0)
+        self.assertTrue(jnp.max(jnp.abs(psiS0 - (-5.549380111605981-0.0316078980423882j))) < 1e-12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
RNN with complex parameters could not be created. To reproduce: 
```
>>> import jVMC
>>> import jax
>>> net = jVMC.nets.RNN1DGeneral(L=4, realValuedParams=False)
>>> params = net.init(jax.random.PRNGKey(0), jax.numpy.zeros(4, dtype=jax.numpy.int32))
```

gives the output

``` 
File site-packages/jVMC/nets/rnn1d_general.py", line 146, in __call__
    _, probs = self.rnn_cell((self.zero_carry, jnp.zeros(self.inputDim)), jax.nn.one_hot(x, self.inputDim))
  File "site-packages/flax/core/axes_scan.py", line 139, in scan_fn
    _, out_pvals, _ = pe.trace_to_jaxpr_nounits(f_flat, in_pvals)
  File "site-packages/flax/core/axes_scan.py", line 115, in body_fn
    broadcast_out, c, ys = fn(broadcast_in, c, *xs)
  File "site-packages/jVMC/nets/rnn1d_general.py", line 154, in rnn_cell
    newCarry, out = self.rnnCell(carry[0], carry[1])
  File "site-packages/jVMC/nets/rnn1d_general.py", line 52, in __call__
    current_carry, newR = cell(c, newR)
  File "site-packages/jVMC/nets/rnn1d_general.py", line 224, in __call__
    newCarry = (self.actFun(cellCarry(carry[0])) + state)[None, :]
  File "site-packages/flax/linen/linear.py", line 196, in __call__
    kernel = self.param('kernel',
TypeError: cplx_variance_scaling() got an unexpected keyword argument 'scale'
```

I fixed the wrong arguments passed to `cplx_variance_scaling()`. Also, in the case of RNN1DGeneral(), the `self.dtype` argument was not passed to `RNNCellStack()` which caused mixing of datatypes (complex and float). I also added tests for RNN with complex parameters, but I am sure it is not a good practice to compare the output of the RNN with the fixed value. But the test allows one to see if the RNN1DGeneral and RNN2DGeneral at least compile.