### PR TITLE
Fix stats.py for MPI

### DIFF
--- a/jVMC/stats.py
+++ b/jVMC/stats.py
@@ -107,7 +107,7 @@ class SampledObs():
                 observations = observations[...,None]
 
             self._weights = weights
-            self._mean = mpi.global_sum( _mean_helper(observations,self._weights)[None,...] )
+            self._mean = mpi.global_sum( _mean_helper(observations,self._weights)[:, None,...]  )
             self._data = _data_prep(observations, self._weights, self._mean)
         else:
             self._weights = weights
@@ -132,7 +132,7 @@ class SampledObs():
         if other is None:
             other = self
         
-        return mpi.global_sum( _covar_helper(self._data, other._data)[None,...] )
+        return mpi.global_sum( _covar_helper(self._data, other._data)[:, None,...]  )
     
 
     def var(self):
@@ -165,7 +165,7 @@ class SampledObs():
         if other is None:
             other = self
         
-        return mpi.global_sum( _covar_var_helper(self._data, other._data, self._weights)[None,...] ) \
+        return mpi.global_sum( _covar_var_helper(self._data, other._data, self._weights)[:, None,...]  ) \
                     - jnp.abs(self.covar(other))**2
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 
-DEFAULT_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax>=0.4.1,<=0.4.11", "jaxlib>=0.4.1,<=0.4.11", "flax>=0.6.4,<=0.6.11", "mpi4py", "h5py", "PyYAML", "matplotlib"]
+DEFAULT_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax>=0.4.1,<=0.4.20", "jaxlib>=0.4.1,<=0.4.20", "flax>=0.6.4,<=0.6.11", "mpi4py", "h5py", "PyYAML", "matplotlib"]
 #CUDA_DEPENDENCIES = ["setuptools", "wheel", "numpy", "jax[cuda]>=0.2.11,<=0.2.25", "flax>=0.3.6,<=0.3.6", "mpi4py", "h5py"]
 DEV_DEPENDENCIES = DEFAULT_DEPENDENCIES + ["sphinx", "mock", "sphinx_rtd_theme", "pytest", "pytest-mpi"]
 

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -5,15 +5,16 @@ import jax.numpy as jnp
 
 from jVMC.stats import SampledObs
 import jVMC.mpi_wrapper as mpi
+from jVMC.global_defs import device_count
 
 
 class TestStats(unittest.TestCase):
 
     def test_sampled_obs(self):
         
-        Obs1Loc = jnp.array([[1,2,3]])
-        Obs2Loc = jnp.array([[[1,4],[2,5],[3,7]]])
-        p = (1./3) * jnp.ones(3)[None,...]
+        Obs1Loc = jnp.array([[1, 2, 3]] * device_count())
+        Obs2Loc = jnp.array([[[1, 4], [2, 5], [3, 7]]] * device_count())
+        p = (1. / (3 * device_count())) * jnp.ones((device_count(), 3))
 
         obs1 = SampledObs(Obs1Loc, p)
         obs2 = SampledObs(Obs2Loc, p)


### PR DESCRIPTION
There was an error in tensor indexing in the ```stats.SampledObs``` calculations of the global sums. Estimation of mean, variance etc. worked only if the leading dimension of ```observations``` and ```weights``` was equal to 1. Otherwise, for ```TestStats.test_sampled_obs``` test with the leading dimension of the input array equal to ```jVMC.global_defs.device_count()``` greater than 1 an error occurred:

```
Ran 1 test in 0.107s

FAILED (errors=1)

Error
jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/c8888/dev/vmc_jax/tests/stats_test.py", line 18, in test_sampled_obs
    obs1 = SampledObs(Obs1Loc, p)
  File "/home/c8888/dev/vmc_jax/jVMC/stats.py", line 120, in __init__
    self._mean = mpi.global_sum(_mean_helper(observations, self._weights)[None, ...])
  File "/home/c8888/dev/vmc_jax/jVMC/mpi_wrapper.py", line 135, in global_sum
    localSum = np.array(_sum_up_pmapd(data)[0])
ValueError: Leading axis size of input to pmapped function must equal the number of local devices passed to pmap. Got axis_size=1, num_local_devices=16.
(Local devices available to pmap: TFRT_CPU_0, TFRT_CPU_1, TFRT_CPU_2, TFRT_CPU_3, TFRT_CPU_4, TFRT_CPU_5, TFRT_CPU_6, TFRT_CPU_7, TFRT_CPU_8, TFRT_CPU_9, TFRT_CPU_10, TFRT_CPU_11, TFRT_CPU_12, TFRT_CPU_13, TFRT_CPU_14, TFRT_CPU_15)

```
This made it impossible to run SR, minSR etc with multiple devices.

It is easy to reproduce these errors without many physical devices by setting the following environment variables before running the test to fake multiple devices:
```
XLA_FLAGS=--xla_force_host_platform_device_count=16;JAX_PLATFORM_NAME=cpu
```

In this pull request I fixed the indexing in ```stats.SampledObs``` and slightly modified the test for stats. 

I am not sure if ```SampledObs.subset``` should also be changed.