### PR TITLE
Add adaptive SVD cutoff.

### DIFF
--- a/jVMC/version.py
+++ b/jVMC/version.py
@@ -1,2 +1,2 @@
 """Current jVMC version at head on Github."""
-__version__ = "1.2.6"
+__version__ = "1.3.0"

--- a/tests/povm_test.py
+++ b/tests/povm_test.py
@@ -45,7 +45,7 @@ class TestPOVM(unittest.TestCase):
         self.sampler = jVMC.sampler.ExactSampler(self.psi, (L,), lDim=4, logProbFactor=1)
 
         self.tdvpEquation = jVMC.util.tdvp.TDVP(self.sampler, rhsPrefactor=-1.,
-                                                svdTol=1e-6, diagonalShift=0, makeReal='real', crossValidation=False)
+                                                pinvTol=0.0, pinvCutoff=1e-6, diagonalShift=0, makeReal='real', crossValidation=False)
 
         #self.stepper = jVMC.util.stepper.Euler(timeStep=dt)  # ODE integrator
         self.stepper = jVMC.util.stepper.Heun(timeStep=dt)  # ODE integrator

--- a/tests/tdvp_test.py
+++ b/tests/tdvp_test.py
@@ -47,7 +47,7 @@ class TestGsSearch(unittest.TestCase):
             exactSampler = sampler.ExactSampler(psi, L)
 
             delta = 2
-            tdvpEquation = jVMC.util.TDVP(exactSampler, snrTol=1, svdTol=1e-8, rhsPrefactor=1., diagonalShift=delta, makeReal='real')
+            tdvpEquation = jVMC.util.TDVP(exactSampler, snrTol=1, pinvTol=0.0, pinvCutoff=1e-8, rhsPrefactor=1., diagonalShift=delta, makeReal='real')
 
             # Perform ground state search to get initial state
             ground_state_search(psi, hamiltonianGS, tdvpEquation, exactSampler, numSteps=100, stepSize=5e-2)
@@ -94,7 +94,7 @@ class TestTimeEvolution(unittest.TestCase):
         # Set up adaptive time stepper
         stepper = jVMCstepper.AdaptiveHeun(timeStep=1e-3, tol=1e-5)
 
-        tdvpEquation = jVMC.util.TDVP(exactSampler, snrTol=1, svdTol=1e-8, rhsPrefactor=1.j, diagonalShift=0., makeReal='imag')
+        tdvpEquation = jVMC.util.TDVP(exactSampler, snrTol=1, pinvTol=0.0, pinvCutoff=1e-8, rhsPrefactor=1.j, diagonalShift=0., makeReal='imag')
 
         t = 0
         obs = []


### PR DESCRIPTION
When the properties of the quantum metric tensor vary during simulations, it can be useful to fix a target tolerance for the solution, i.e. $||S\dot\theta-F||/||F||\overset{!}{<}\tau$, and choose the pseudo-inverse cutoff $\epsilon_{SVD}$ adaptively such that the tolerance is reached.