### PR TITLE
Fix excessive compilations in the MC sampler

### DIFF
--- a/jVMC/version.py
+++ b/jVMC/version.py
@@ -1,2 +1,2 @@
 """Current jVMC version at head on Github."""
-__version__ = "1.5.1"
+__version__ = "1.5.2"


### PR DESCRIPTION
There was an issue with a slow but steady memory growth during TDVP as described here: [[https://github.com/markusschmitt/vmc_jax/issues/78](https://github.com/markusschmitt/vmc_jax/issues/78)]

If one executes `jax.clear_cache()` every few steps of the TDVP, this issue is fixed. This points to an unnecessary JIT compilation happening somewhere during the TDVP step.
One can check that the program indeed performs some compilations during TDVP steps by setting the environment variable `JAX_LOG_COMPILES=1` and observing the output.

I found that the problem was caused by the `MCSampler` object through `self._mc_init(params) ` function which calculates `self.logAccProb`. A pmap'd version of the function is compiled every time one asks the sampler for samples . A solution is to compile this function once and store as the object property. This PR realizes that.

In a typical use-case, the speed-up due to avoidance of recompilations is minor, but after this change the consumed RAM memory does not grow indefinitely after each `sampler.sample()` call.