### PR TITLE
MinSR modification

### DIFF
--- a/jVMC/nets/rnn2d_general.py
+++ b/jVMC/nets/rnn2d_general.py
@@ -129,7 +129,7 @@ class RNN2DGeneral(nn.Module):
                 self.cells = [LSTMCell(features=self.hiddenSize) for _ in range(self.depth)]
                 self.zero_carry = jnp.zeros((self.L, self.depth, 2, self.hiddenSize), dtype=self.dtype)
             elif self.cell == "GRU":
-                self.cells = [GRUCell() for _ in range(self.depth)]
+                self.cells = [GRUCell(features=self.hiddenSize) for _ in range(self.depth)]
             else:
                 ValueError("Cell name not recognized.")
         else:
@@ -246,10 +246,10 @@ class GRUCell(nn.Module):
     def __call__(self, carryH, carryV, state):
         cellCarryH = nn.Dense(features=carryH.shape[-1],
                               use_bias=True,
-                              dtype=global_defs.tReal)
+                              param_dtype=global_defs.tReal)
         cellCarryV = nn.Dense(features=carryV.shape[-1],
                               use_bias=False,
-                              dtype=global_defs.tReal)
+                              param_dtype=global_defs.tReal)
         current_carry, newR = nn.GRUCell(features=self.features, param_dtype=global_defs.tReal)(cellCarryH(carryH) + cellCarryV(carryV), state)
 
         return current_carry, newR[0]

--- a/tests/minsr_test.py
+++ b/tests/minsr_test.py
@@ -33,7 +33,7 @@ class TestGsSearch(unittest.TestCase):
             # Set up exact sampler
             exactSampler = sampler.ExactSampler(psi, L)
 
-            tdvpEquation = jVMC.util.MinSR(exactSampler, pinvTol=1e-8, makeReal='real')
+            tdvpEquation = jVMC.util.MinSR(exactSampler, pinvTol=1e-8, diagonalShift=0.)
 
             # Perform ground state search to get initial state
             ground_state_search(psi, hamiltonianGS, tdvpEquation, exactSampler, numSteps=100, stepSize=5e-2)


### PR DESCRIPTION
MinSR is modified to use the concatenation of the real and imaginary parts of the gradients, as explained in [arXiv:2310.05715](https://arxiv.org/abs/2310.05715).
I kept the original implementation as an option since it should be more efficient when the parameters are complex.

There are also a few bug fixes included for the GRU cell in the 2D RNN.