### PR TITLE
Fix docstrings for Python 3.12

### DIFF
--- a/jVMC/mpi_wrapper.py
+++ b/jVMC/mpi_wrapper.py
@@ -157,7 +157,7 @@ def global_mean(data, p):
 
     The mean is computed using the given probabilities, i.e.,
 
-        :math:`\\langle X\\rangle=\sum_{j=1}^{N_S} p_jX_j`
+        :math:`\\langle X\\rangle=\\sum_{j=1}^{N_S} p_jX_j`
 
     Arguments:
         * ``data``: Array of input data.
@@ -184,7 +184,7 @@ def global_variance(data, p):
 
     The mean is computed using the given probabilities, i.e.,
 
-        :math:`\\text{Var}(X)=\sum_{j=1}^{N_S} p_j |X_j-\\langle X\\rangle|^2`
+        :math:`\\text{Var}(X)=\\sum_{j=1}^{N_S} p_j |X_j-\\langle X\\rangle|^2`
 
     Arguments:
         * ``data``: Array of input data.
@@ -228,7 +228,7 @@ def global_covariance(data, p):
 
     The mean is computed using the given probabilities, i.e.,
 
-        :math:`\\text{Cov}(X)=\sum_{j=1}^{N_S} p_jX_j\\cdot X_j^\\dagger - \\bigg(\sum_{j=1}^{N_S} p_jX_j\\bigg)\\cdot\\bigg(\sum_{j=1}^{N_S}p_jX_j^\\dagger\\bigg)`
+        :math:`\\text{Cov}(X)=\\sum_{j=1}^{N_S} p_jX_j\\cdot X_j^\\dagger - \\bigg(\\sum_{j=1}^{N_S} p_jX_j\\bigg)\\cdot\\bigg(\\sum_{j=1}^{N_S}p_jX_j^\\dagger\\bigg)`
 
     Arguments:
         * ``data``: Array of input data.

--- a/jVMC/nets/rnn1d_general.py
+++ b/jVMC/nets/rnn1d_general.py
@@ -69,9 +69,9 @@ class RNN1DGeneral(nn.Module):
     This model can produce real positive or complex valued output. In either case the output is
     normalized such that
 
-        :math:`\sum_s |RNN(s)|^{1/\kappa}=1`.
+        :math:`\\sum_s |RNN(s)|^{1/\\kappa}=1`.
 
-    Here, :math:`\kappa` corresponds to the initialization parameter ``logProbFactor``. Thereby, the RNN
+    Here, :math:`\\kappa` corresponds to the initialization parameter ``logProbFactor``. Thereby, the RNN
     can represent both probability distributions and wave functions. Real or complex valued output is 
     chosen through the parameter ``realValuedOutput``.
 

--- a/jVMC/nets/rnn2d_general.py
+++ b/jVMC/nets/rnn2d_general.py
@@ -77,9 +77,9 @@ class RNN2DGeneral(nn.Module):
     This model can produce real positive or complex valued output. In either case the output is
     normalized such that
 
-        :math:`\sum_s |RNN(s)|^{1/\kappa}=1`.
+        :math:`\\sum_s |RNN(s)|^{1/\\kappa}=1`.
 
-    Here, :math:`\kappa` corresponds to the initialization parameter ``logProbFactor``. Thereby, the RNN
+    Here, :math:`\\kappa` corresponds to the initialization parameter ``logProbFactor``. Thereby, the RNN
     can represent both probability distributions and wave functions. Real or complex valued output is 
     chosen through the parameter ``realValuedOutput``.
 

--- a/jVMC/operator/base.py
+++ b/jVMC/operator/base.py
@@ -42,7 +42,7 @@ class Operator(metaclass=abc.ABCMeta):
 
     **Example:**
 
-        Here we define a :math:`\hat\sigma_1^x` operator acting on lattice site :math:`1` of a spin-1/2 chain.
+        Here we define a :math:`\\hat\\sigma_1^x` operator acting on lattice site :math:`1` of a spin-1/2 chain.
 
         .. literalinclude:: ../../examples/ex1_custom_operator.py
                 :linenos:
@@ -117,7 +117,7 @@ class Operator(metaclass=abc.ABCMeta):
         """Compute matrix elements
 
         For a list of computational basis states :math:`s` this member function computes the corresponding \
-        matrix elements :math:`O_{s,s'}=\langle s|\hat O|s'\\rangle` and their respective configurations \
+        matrix elements :math:`O_{s,s'}=\\langle s|\\hat O|s'\\rangle` and their respective configurations \
         :math:`s'`.
 
         Arguments:
@@ -172,7 +172,7 @@ class Operator(metaclass=abc.ABCMeta):
         Arguments:
             * ``samples``: Sample of computational basis configurations :math:`s`.
             * ``psi``: Neural quantum state.
-            * ``logPsiS``: Logarithmic amplitudes :math:`\\ln(\psi(s))`
+            * ``logPsiS``: Logarithmic amplitudes :math:`\\ln(\\psi(s))`
             * ``*args``: Further positional arguments for the operator.
 
         Returns:
@@ -197,13 +197,13 @@ class Operator(metaclass=abc.ABCMeta):
         This member function assumes that ``get_s_primes(s)`` has been called before, as \
         internally stored matrix elements :math:`O_{s,s'}` are used.
 
-        Computes :math:`O_{loc}(s)=\sum_{s'} O_{s,s'}\\frac{\psi(s')}{\psi(s)}`, given the \
-        logarithmic wave function amplitudes of the involved configurations :math:`\\ln(\psi(s))` \
-        and :math:`\\ln\psi(s')`
+        Computes :math:`O_{loc}(s)=\\sum_{s'} O_{s,s'}\\frac{\\psi(s')}{\\psi(s)}`, given the \
+        logarithmic wave function amplitudes of the involved configurations :math:`\\ln(\\psi(s))` \
+        and :math:`\\ln\\psi(s')`
 
         Arguments:
-            * ``logPsiS``: Logarithmic amplitudes :math:`\\ln(\psi(s))`
-            * ``logPsiSP``: Logarithmic amplitudes :math:`\\ln(\psi(s'))`
+            * ``logPsiS``: Logarithmic amplitudes :math:`\\ln(\\psi(s))`
+            * ``logPsiSP``: Logarithmic amplitudes :math:`\\ln(\\psi(s'))`
 
         Returns:
             :math:`O_{loc}(s)` for each configuration :math:`s`.
@@ -214,13 +214,13 @@ class Operator(metaclass=abc.ABCMeta):
     def get_O_loc_batched(self, samples, psi, logPsiS, batchSize, *args):
         """Compute :math:`O_{loc}(s)` in batches.
 
-        Computes :math:`O_{loc}(s)=\sum_{s'} O_{s,s'}\\frac{\psi(s')}{\psi(s)}` in a batch-wise manner
+        Computes :math:`O_{loc}(s)=\\sum_{s'} O_{s,s'}\\frac{\\psi(s')}{\\psi(s)}` in a batch-wise manner
         to avoid out-of-memory issues.
 
         Arguments:
             * ``samples``: Sample of computational basis configurations :math:`s`.
             * ``psi``: Neural quantum state.
-            * ``logPsiS``: Logarithmic amplitudes :math:`\\ln(\psi(s))`
+            * ``logPsiS``: Logarithmic amplitudes :math:`\\ln(\\psi(s))`
             * ``batchSize``: Batch size.
             * ``*args``: Further positional arguments for the operator.
 
@@ -287,8 +287,8 @@ class Operator(metaclass=abc.ABCMeta):
     def get_estimator_function(self, psi, *args):
         """Get a function that computes :math:`O_{loc}(\\theta, s)`.
 
-        Returns a function that computes :math:`O_{loc}(\\theta, s)=\sum_{s'} O_{s,s'}\\frac{\psi_\\theta(s')}{\psi_\\theta(s)}` 
-        for a given configuration :math:`s` and parameters :math:`\\theta` of a given ansatz :math:`\psi_\\theta(s)`.
+        Returns a function that computes :math:`O_{loc}(\\theta, s)=\\sum_{s'} O_{s,s'}\\frac{\\psi_\\theta(s')}{\\psi_\\theta(s)}` 
+        for a given configuration :math:`s` and parameters :math:`\\theta` of a given ansatz :math:`\\psi_\\theta(s)`.
 
         Arguments:
             * ``psi``: Neural quantum state.

--- a/jVMC/operator/branch_free.py
+++ b/jVMC/operator/branch_free.py
@@ -34,14 +34,14 @@ def Id(idx=0, lDim=2):
 
 
 def Sx(idx):
-    """Returns a :math:`\hat\sigma^x` Pauli operator
+    """Returns a :math:`\\hat\\sigma^x` Pauli operator
 
     Args:
 
     * ``idx``: Index of the local Hilbert space.
 
     Returns:
-        Dictionary defining :math:`\hat\sigma^x` Pauli operator
+        Dictionary defining :math:`\\hat\\sigma^x` Pauli operator
 
     """
 
@@ -52,14 +52,14 @@ def Sx(idx):
 
 
 def Sy(idx):
-    """Returns a :math:`\hat\sigma^x` Pauli operator
+    """Returns a :math:`\\hat\\sigma^x` Pauli operator
 
     Args:
 
     * ``idx``: Index of the local Hilbert space.
 
     Returns:
-        Dictionary defining :math:`\hat\sigma^x` Pauli operator
+        Dictionary defining :math:`\\hat\\sigma^x` Pauli operator
 
     """
 
@@ -70,14 +70,14 @@ def Sy(idx):
 
 
 def Sz(idx):
-    """Returns a :math:`\hat\sigma^z` Pauli operator
+    """Returns a :math:`\\hat\\sigma^z` Pauli operator
 
     Args:
 
     * ``idx``: Index of the local Hilbert space.
 
     Returns:
-        Dictionary defining :math:`\hat\sigma^z` Pauli operator
+        Dictionary defining :math:`\\hat\\sigma^z` Pauli operator
 
     """
 
@@ -126,14 +126,14 @@ def Sm(idx):
 ######################
 # fermionic number operator
 def number(idx):
-    """Returns a :math:`c^\dagger c` fermionic number operator
+    """Returns a :math:`c^\\dagger c` fermionic number operator
 
     Args:
 
     * ``idx``: Index of the local Hilbert space.
 
     Returns:
-        Dictionary defining :math:`c^\dagger c` fermionic number operator
+        Dictionary defining :math:`c^\\dagger c` fermionic number operator
 
     """
 
@@ -148,14 +148,14 @@ def number(idx):
 ######################
 # fermionic creation operator
 def creation(idx): 
-    """Returns a :math:`c^\dagger` fermionic creation operator
+    """Returns a :math:`c^\\dagger` fermionic creation operator
 
     Args:
 
     * ``idx``: Index of the local Hilbert space.
 
     Returns:
-        Dictionary defining :math:`c^\dagger` fermionic creation operator
+        Dictionary defining :math:`c^\\dagger` fermionic creation operator
 
     """
     

--- a/jVMC/operator/povm.py
+++ b/jVMC/operator/povm.py
@@ -131,13 +131,13 @@ def matrix_to_povm(A, M, T_inv, mode='unitary', dtype=opDtype):
 
 
     In unitary mode this function implements
-    :math:`\Omega^{ab} = -i T^{-1 bc}  \mathrm{Tr}(A [M^c, M^a])`,
+    :math:`\\Omega^{ab} = -i T^{-1 bc}  \\mathrm{Tr}(A [M^c, M^a])`,
     in dissipative mode
-    :math:`\Omega^{ab} = T^{-1 bc} \mathrm{Tr}(A M^c A^\dagger M^a- 1/2 A^\dagger A \{M^c, M^a\})`,
+    :math:`\\Omega^{ab} = T^{-1 bc} \\mathrm{Tr}(A M^c A^\\dagger M^a- 1/2 A^\\dagger A \\{M^c, M^a\\})`,
     in observable mode
-    :math:`O^a = T^{-1 ab} \mathrm{Tr}(M^b A)`
+    :math:`O^a = T^{-1 ab} \\mathrm{Tr}(M^b A)`
     and in imaginary time mode
-    :math:`\Omega^{ab} = - T^{-1 bc} \mathrm{Tr}(A \{M^c, M^a\})`
+    :math:`\\Omega^{ab} = - T^{-1 bc} \\mathrm{Tr}(A \\{M^c, M^a\\})`
     where the Einstein sum convention is assumed.
 
     Args:

--- a/jVMC/sampler.py
+++ b/jVMC/sampler.py
@@ -73,7 +73,7 @@ class MCSampler:
         :math:`p_{\\mu}(s)=\\frac{|\\psi(s)|^{\\mu}}{\\sum_s|\\psi(s)|^{\\mu}}`.
 
     For :math:`\\mu=2` this corresponds to sampling from the Born distribution. \
-    :math:`0\leq\\mu<2` can be used to perform importance sampling \
+    :math:`0\\leq\\mu<2` can be used to perform importance sampling \
     (see `[arXiv:2108.08631] <https://arxiv.org/abs/2108.08631>`_).
 
     Sampling is automatically distributed accross MPI processes and locally available \
@@ -506,7 +506,7 @@ class ExactSampler:
         Returns:
             ``configs, logPsi, p``: All computational basis configurations, \
             corresponding wave function coefficients, and probabilities \
-            :math:`|\psi(s)|^2` (normalized).
+            :math:`|\\psi(s)|^2` (normalized).
         """
 
         if parameters is not None:

--- a/jVMC/util/minsr.py
+++ b/jVMC/util/minsr.py
@@ -20,7 +20,7 @@ class MinSR:
 
     Initializer arguments:
         * ``sampler``: A sampler object.
-        * ``svdTol``: Regularization parameter :math:`\epsilon_{SVD}`, see above.
+        * ``svdTol``: Regularization parameter :math:`\\epsilon_{SVD}`, see above.
         * ``makeReal``: Specifies the function :math:`q`, either `'real'` for :math:`q=\\text{Re}` \
             or `'imag'` for :math:`q=\\text{Im}`.
         * ``diagonalizeOnDevice``: Choose whether to diagonalize :math:`S` on GPU or CPU.

--- a/jVMC/util/tdvp.py
+++ b/jVMC/util/tdvp.py
@@ -28,13 +28,13 @@ class TDVP:
 
     With the force vector
 
-        :math:`F_k=\langle \mathcal O_{\\theta_k}^* E_{loc}^{\\theta}\\rangle_c`
+        :math:`F_k=\\langle \\mathcal O_{\\theta_k}^* E_{loc}^{\\theta}\\rangle_c`
 
     and the quantum Fisher matrix
 
-        :math:`S_{k,k'} = \langle (\mathcal O_{\\theta_k})^* \mathcal O_{\\theta_{k'}}\\rangle_c`
+        :math:`S_{k,k'} = \\langle (\\mathcal O_{\\theta_k})^* \\mathcal O_{\\theta_{k'}}\\rangle_c`
 
-    and for real parameters :math:`\\theta\in\mathbb R`, the TDVP equation reads
+    and for real parameters :math:`\\theta\\in\\mathbb R`, the TDVP equation reads
 
         :math:`q\\big[S_{k,k'}\\big]\\dot\\theta_{k'} = -q\\big[xF_k\\big]`
 
@@ -44,26 +44,26 @@ class TDVP:
     For ground state search a regularization controlled by a parameter :math:`\\rho` can be included
     by increasing the diagonal entries and solving
 
-        :math:`q\\big[(1+\\rho\delta_{k,k'})S_{k,k'}\\big]\\theta_{k'} = -q\\big[F_k\\big]`
+        :math:`q\\big[(1+\\rho\\delta_{k,k'})S_{k,k'}\\big]\\theta_{k'} = -q\\big[F_k\\big]`
 
     The `TDVP` class solves the TDVP equation by computing a pseudo-inverse of :math:`S` via
     eigendecomposition yielding
 
-        :math:`S = V\Sigma V^\dagger`
+        :math:`S = V\\Sigma V^\\dagger`
 
-    with a diagonal matrix :math:`\Sigma_{kk}=\sigma_k`
-    Assuming that :math:`\sigma_1` is the smallest eigenvalue, the pseudo-inverse is constructed 
+    with a diagonal matrix :math:`\\Sigma_{kk}=\\sigma_k`
+    Assuming that :math:`\\sigma_1` is the smallest eigenvalue, the pseudo-inverse is constructed 
     from the regularized inverted eigenvalues
 
-        :math:`\\tilde\sigma_k^{-1}=\\frac{1}{\\Big(1+\\big(\\frac{\epsilon_{SVD}}{\sigma_j/\sigma_1}\\big)^6\\Big)\\Big(1+\\big(\\frac{\epsilon_{SNR}}{\\text{SNR}(\\rho_k)}\\big)^6\\Big)}`
+        :math:`\\tilde\\sigma_k^{-1}=\\frac{1}{\\Big(1+\\big(\\frac{\\epsilon_{SVD}}{\\sigma_j/\\sigma_1}\\big)^6\\Big)\\Big(1+\\big(\\frac{\\epsilon_{SNR}}{\\text{SNR}(\\rho_k)}\\big)^6\\Big)}`
 
-    with :math:`\\text{SNR}(\\rho_k)` the signal-to-noise ratio of :math:`\\rho_k=V_{k,k'}^{\dagger}F_{k'}` (see `[arXiv:1912.08828] <https://arxiv.org/pdf/1912.08828.pdf>`_ for details).
+    with :math:`\\text{SNR}(\\rho_k)` the signal-to-noise ratio of :math:`\\rho_k=V_{k,k'}^{\\dagger}F_{k'}` (see `[arXiv:1912.08828] <https://arxiv.org/pdf/1912.08828.pdf>`_ for details).
 
     Initializer arguments:
         * ``sampler``: A sampler object.
-        * ``snrTol``: Regularization parameter :math:`\epsilon_{SNR}`, see above.
-        * ``pinvTol``: Regularization parameter :math:`\epsilon_{SVD}` (see above) is chosen such that :math:`||S\\dot\\theta-F|| / ||F||<pinvTol`.
-        * ``pinvCutoff``: Lower bound for the regularization parameter :math:`\epsilon_{SVD}`, see above.
+        * ``snrTol``: Regularization parameter :math:`\\epsilon_{SNR}`, see above.
+        * ``pinvTol``: Regularization parameter :math:`\\epsilon_{SVD}` (see above) is chosen such that :math:`||S\\dot\\theta-F|| / ||F||<pinvTol`.
+        * ``pinvCutoff``: Lower bound for the regularization parameter :math:`\\epsilon_{SVD}`, see above.
         * ``makeReal``: Specifies the function :math:`q`, either `'real'` for :math:`q=\\text{Re}` or `'imag'` for :math:`q=\\text{Im}`.
         * ``rhsPrefactor``: Prefactor :math:`x` of the right hand side, see above.
         * ``diagonalShift``: Regularization parameter :math:`\\rho` for ground state search, see above.

--- a/jVMC/version.py
+++ b/jVMC/version.py
@@ -1,2 +1,2 @@
 """Current jVMC version at head on Github."""
-__version__ = "1.5.3"
+__version__ = "1.5.4"

--- a/jVMC/vqs.py
+++ b/jVMC/vqs.py
@@ -87,15 +87,15 @@ class NQS:
     
     This class can operate in two modi:
         #. Single-network ansatz
-            Quantum state of the form :math:`\psi_\\theta(s)\equiv\exp(r_\\theta(s))`, \
+            Quantum state of the form :math:`\\psi_\\theta(s)\\equiv\\exp(r_\\theta(s))`, \
             where the network :math:`r_\\theta` is
             a) holomorphic, i.e., parametrized by complex valued parameters :math:`\\vartheta`.
             b) non-holomorphic, i.e., parametrized by real valued parameters :math:`\\theta`.
         #. Two-network ansatz
             Quantum state of the form 
-            :math:`\psi_\\theta(s)\equiv\exp(r_{\\theta_r}(s)+i\\varphi_{\\theta_\\phi}(s))` \
+            :math:`\\psi_\\theta(s)\\equiv\\exp(r_{\\theta_r}(s)+i\\varphi_{\\theta_\\phi}(s))` \
             with an amplitude network :math:`r_{\\theta_{r}}` and a phase network \
-            :math:`\\varphi_{\\theta_\phi}` \
+            :math:`\\varphi_{\\theta_\\phi}` \
             parametrized by real valued parameters :math:`\\theta_r,\\theta_\\phi`.
 
     Initializer arguments:
@@ -122,15 +122,15 @@ class NQS:
         
         This class can operate in two modi:
             #. Single-network ansatz
-                Quantum state of the form :math:`\psi_\\theta(s)\equiv\exp(r_\\theta(s))`, \
+                Quantum state of the form :math:`\\psi_\\theta(s)\\equiv\\exp(r_\\theta(s))`, \
                 where the network :math:`r_\\theta` is
                 a) holomorphic, i.e., parametrized by complex valued parameters :math:`\\vartheta`.
                 b) non-holomorphic, i.e., parametrized by real valued parameters :math:`\\theta`.
             #. Two-network ansatz
                 Quantum state of the form 
-                :math:`\psi_\\theta(s)\equiv\exp(r_{\\theta_r}(s)+i\\varphi_{\\theta_\\phi}(s))` \
+                :math:`\\psi_\\theta(s)\\equiv\\exp(r_{\\theta_r}(s)+i\\varphi_{\\theta_\\phi}(s))` \
                 with an amplitude network :math:`r_{\\theta_{r}}` and a phase network \
-                :math:`\\varphi_{\\theta_\phi}` \
+                :math:`\\varphi_{\\theta_\\phi}` \
                 parametrized by real valued parameters :math:`\\theta_r,\\theta_\\phi`.
         Args:       
             * ``net``: Variational network or tuple of networks.
@@ -139,7 +139,7 @@ class NQS:
                 If a tuple of two networks is given, the first is used for the logarithmic \
                 amplitude and the second for the phase of the wave function coefficient.
             * ``logarithmic``: Boolean variable indicating, whether the ANN returns logarithmic \
-                (:math:`\log\psi_\theta(s)`) or plain (:math:`\psi_\theta(s)`) wave function coefficients.
+                (:math:`\\log\\psi_\\theta(s)`) or plain (:math:`\\psi_\\theta(s)`) wave function coefficients.
             * ``batchSize``: Batch size for batched network evaluation. Choice \
                 of this parameter impacts performance: with too small values performance \
                 is limited by memory access overheads, too large values can lead \
@@ -223,13 +223,13 @@ class NQS:
     def __call__(self, s):
         """Evaluate variational wave function.
         
-        Compute the logarithmic wave function coefficients :math:`\ln\psi(s)` for \
+        Compute the logarithmic wave function coefficients :math:`\\ln\\psi(s)` for \
         computational configurations :math:`s`.
         
         Args:
             * ``s``: Array of computational basis states.
         Returns:
-            Logarithmic wave function coefficients :math:`\ln\psi(s)`.
+            Logarithmic wave function coefficients :math:`\\ln\\psi(s)`.
         
         :meta public:
         """
@@ -272,12 +272,12 @@ class NQS:
         """Compute gradients of logarithmic wave function.
         
         Compute gradient of the logarithmic wave function coefficients, \
-        :math:`\\nabla\ln\psi(s)`, for computational configurations :math:`s`.
+        :math:`\\nabla\\ln\\psi(s)`, for computational configurations :math:`s`.
         
         Args:
             * ``s``: Array of computational basis states.
         Returns:
-            A vector containing derivatives :math:`\partial_{\\theta_k}\ln\psi(s)` \
+            A vector containing derivatives :math:`\\partial_{\\theta_k}\\ln\\psi(s)` \
             with respect to each variational parameter :math:`\\theta_k` for each \
             input configuration :math:`s`.
         """
@@ -293,12 +293,12 @@ class NQS:
         """Compute gradients of logarithmic wave function and return them as dictionary.
         
         Compute gradient of the logarithmic wave function coefficients, \
-        :math:`\\nabla\ln\psi(s)`, for computational configurations :math:`s`.
+        :math:`\\nabla\\ln\\psi(s)`, for computational configurations :math:`s`.
         
         Args:
             * ``s``: Array of computational basis states.
         Returns:
-            A dictionary containing derivatives :math:`\partial_{\\theta_k}\ln\psi(s)` \
+            A dictionary containing derivatives :math:`\\partial_{\\theta_k}\\ln\\psi(s)` \
             with respect to each variational parameter :math:`\\theta_k` for each \
             input configuration :math:`s`.
         """
@@ -338,7 +338,7 @@ class NQS:
         """Get real part of NQS and current parameters
 
         This function returns a function that evaluates the real part of the NQS,
-        :math:`\\text{Re}(\log\psi(s))`, and the current parameters.
+        :math:`\\text{Re}(\\log\\psi(s))`, and the current parameters.
 
         Returns:
             Real part of the NQS and current parameters


### PR DESCRIPTION
Converted all `\` to `\\` in docstrings for compatibility with Python 3.12.