### PR TITLE
Fix some bugs with prefactors in `BranchFreeOperator`

### DIFF
--- a/documentation/source/parallelism.rst
+++ b/documentation/source/parallelism.rst
@@ -94,3 +94,15 @@ is crucial. This applies in particular to wave function evaluations. Therefore,
 any operation implemented in `jVMC` is performed on a batch of input data. This
 means that following the leading `device dimension`, any data arrays passed to or 
 obtained from the `jVMC` API have an additional `batch dimension`.
+
+MPI
+^^^
+If you are running your simulation with multiple MPI processes, `jVMC` automatically
+parallelized the Monte Carlo sampling tasks across these. If your machine has multiple
+GPUs attached to each node and all of them are visible, you may want to assign one GPU 
+per MPI process. This is achieved by the following line:
+
+.. code-block::
+
+    jVMC.global_defs.set_pmap_devices(jax.devices()[jVMC.mpi_wrapper.rank % jax.device_count()])
+

--- a/jVMC/version.py
+++ b/jVMC/version.py
@@ -1,2 +1,2 @@
 """Current jVMC version at head on Github."""
-__version__ = "1.5.4"
+__version__ = "1.5.5"


### PR DESCRIPTION
There were two bugs connected to prefactors in `BranchFreeOperator`:
- When running with multiple MPI processes, the parallel jit compilation was not properly distributed.
- When composing operators without prefactors, the operator description was not a tuple.

Also added some more explanation to the documentation about running with MPI.